### PR TITLE
Add module type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@cloudscape-design/demos",
   "version": "3.0.0",
+  "type": "module",
   "scripts": {
     "typecheck": "tsc",
     "clean": "rm -rf lib",


### PR DESCRIPTION
Added `"type": "module"` field to package.json to enable ES module support for the project.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/spark-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->