### PR TITLE
Add weather dashboard with forecasts and charts

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Comprehensive weather dashboard with forecasts and charts.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -45,26 +45,37 @@ export function App() {
   };
 
   return (
+    // Provide context for tools panel content management to all child components
     <HelpPanelProvider value={handleToolsContentChange}>
+      {/* Main application layout using Cloudscape's CustomAppLayout wrapper */}
       <CustomAppLayout
         ref={appLayout}
+        // Main content area containing the dashboard header and weather widgets
         content={
           <SpaceBetween size="m">
+            {/* Dashboard header with title, description, and refresh action */}
             <WeatherHeader
               actions={
+                // Primary action button to refresh weather data by reloading the page
                 <Button variant="primary" iconName="refresh" onClick={() => window.location.reload()}>
                   Refresh Data
                 </Button>
               }
             />
+            {/* Main weather dashboard content with all widgets and functionality */}
             <WeatherContent />
           </SpaceBetween>
         }
+        // Navigation breadcrumbs showing current page location
         breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        // Left sidebar navigation menu for weather dashboard sections
         navigation={<WeatherSideNavigation />}
+        // Right sidebar tools panel content (help, info, tutorials)
         tools={toolsContent}
+        // Control tools panel open/closed state
         toolsOpen={toolsOpen}
         onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        // Global notifications component for system messages
         notifications={<Notifications />}
       />
     </HelpPanelProvider>

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherContent } from './components/weather-content';
+import { WeatherHeader, WeatherMainInfo } from './components/weather-header';
+import { WeatherSideNavigation } from './components/weather-side-navigation';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherHeader
+              actions={
+                <Button variant="primary" iconName="refresh" onClick={() => window.location.reload()}>
+                  Refresh Data
+                </Button>
+              }
+            />
+            <WeatherContent />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        navigation={<WeatherSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -12,15 +12,36 @@ import { WeatherContent } from './components/weather-content';
 import { WeatherHeader, WeatherMainInfo } from './components/weather-header';
 import { WeatherSideNavigation } from './components/weather-side-navigation';
 
+/**
+ * Main Weather Dashboard Application Component
+ *
+ * This component serves as the main entry point for the weather dashboard application.
+ * It sets up the overall layout structure using Cloudscape's AppLayout pattern and manages
+ * the state for the help panel/tools sidebar functionality.
+ */
 export function App() {
+  // State to control whether the tools panel (right sidebar) is open or closed
   const [toolsOpen, setToolsOpen] = useState(false);
+
+  // State to control the content displayed in the tools panel
+  // Initialized with WeatherMainInfo component showing dashboard information
   const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
+
+  // Reference to the AppLayout component for programmatic control (e.g., focus management)
   const appLayout = useRef<AppLayoutProps.Ref>(null);
 
+  /**
+   * Handler function for changing the tools panel content
+   *
+   * This function is passed to child components via HelpPanelProvider context,
+   * allowing them to update the tools panel with relevant help content.
+   *
+   * @param content - The React node content to display in the tools panel
+   */
   const handleToolsContentChange = (content: React.ReactNode) => {
-    setToolsOpen(true);
-    setToolsContent(content);
-    appLayout.current?.focusToolsClose();
+    setToolsOpen(true); // Automatically open the tools panel when content changes
+    setToolsContent(content); // Update the tools panel content
+    appLayout.current?.focusToolsClose(); // Focus the close button for accessibility
   };
 
   return (

--- a/src/pages/weather-dashboard/components/current-weather-widget.tsx
+++ b/src/pages/weather-dashboard/components/current-weather-widget.tsx
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherData, WEATHER_CODES } from '../types';
+
+interface CurrentWeatherWidgetProps {
+  weatherData: WeatherData;
+}
+
+export function CurrentWeatherWidget({ weatherData }: CurrentWeatherWidgetProps) {
+  const { current, location } = weatherData;
+  const weatherInfo = WEATHER_CODES[current.weatherCode] || {
+    description: 'Unknown',
+    icon: '❓',
+  };
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleString();
+  };
+
+  const getWindDirection = (degrees: number) => {
+    const directions = [
+      'N',
+      'NNE',
+      'NE',
+      'ENE',
+      'E',
+      'ESE',
+      'SE',
+      'SSE',
+      'S',
+      'SSW',
+      'SW',
+      'WSW',
+      'W',
+      'WNW',
+      'NW',
+      'NNW',
+    ];
+    const index = Math.round(degrees / 22.5) % 16;
+    return directions[index];
+  };
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`Current weather conditions for ${location.name}`}
+          info={<StatusIndicator type="success">Live Data</StatusIndicator>}
+        >
+          Current Weather
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {/* Main Weather Display */}
+        <ColumnLayout columns={3}>
+          <div style={{ textAlign: 'center' }}>
+            <Box fontSize="display-l" fontWeight="bold">
+              {Math.round(current.temperature)}°C
+            </Box>
+            <Box variant="p" color="text-status-info">
+              Temperature
+            </Box>
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <Box fontSize="heading-xl">{weatherInfo.icon}</Box>
+            <Box variant="p" color="text-status-info">
+              {weatherInfo.description}
+            </Box>
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <Box fontSize="heading-l" fontWeight="bold">
+              {current.humidity}%
+            </Box>
+            <Box variant="p" color="text-status-info">
+              Humidity
+            </Box>
+          </div>
+        </ColumnLayout>
+
+        {/* Detailed Information */}
+        <KeyValuePairs
+          columns={4}
+          items={[
+            {
+              label: 'Wind Speed',
+              value: `${Math.round(current.windSpeed)} km/h`,
+            },
+            {
+              label: 'Wind Direction',
+              value: `${getWindDirection(current.windDirection)} (${Math.round(current.windDirection)}°)`,
+            },
+            {
+              label: 'Last Updated',
+              value: formatTime(current.time),
+            },
+            {
+              label: 'Location',
+              value: location.name,
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/components/daily-forecast-widget.tsx
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+
+import { DailyForecast, WEATHER_CODES } from '../types';
+
+interface DailyForecastWidgetProps {
+  dailyData: DailyForecast;
+}
+
+export function DailyForecastWidget({ dailyData }: DailyForecastWidgetProps) {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    }
+    if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    }
+    return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+  };
+
+  const tableItems = dailyData.time.map((time, index) => ({
+    time,
+    date: formatDate(time),
+    temperatureMax: Math.round(dailyData.temperatureMax[index]),
+    temperatureMin: Math.round(dailyData.temperatureMin[index]),
+    precipitation: dailyData.precipitation[index],
+    windSpeed: Math.round(dailyData.windSpeed[index]),
+    weatherCode: dailyData.weatherCode[index],
+    weatherInfo: WEATHER_CODES[dailyData.weatherCode[index]] || { description: 'Unknown', icon: '❓' },
+  }));
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="7-day weather forecast">
+          Daily Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'date',
+            header: 'Date',
+            cell: item => <Box variant="strong">{item.date}</Box>,
+            minWidth: 100,
+          },
+          {
+            id: 'weather',
+            header: 'Condition',
+            cell: item => (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span style={{ fontSize: '1.2em' }}>{item.weatherInfo.icon}</span>
+                <span>{item.weatherInfo.description}</span>
+              </div>
+            ),
+            minWidth: 150,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => (
+              <div>
+                <Box variant="strong">{item.temperatureMax}°C</Box>
+                <Box variant="small" color="text-status-inactive">
+                  {item.temperatureMin}°C
+                </Box>
+              </div>
+            ),
+            minWidth: 100,
+          },
+          {
+            id: 'precipitation',
+            header: 'Precipitation',
+            cell: item => `${item.precipitation.toFixed(1)} mm`,
+            minWidth: 100,
+          },
+          {
+            id: 'wind',
+            header: 'Max Wind',
+            cell: item => `${item.windSpeed} km/h`,
+            minWidth: 100,
+          },
+        ]}
+        items={tableItems}
+        trackBy="time"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No daily forecast available</b>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/hourly-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/components/hourly-forecast-widget.tsx
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+
+import { HourlyForecast, WEATHER_CODES } from '../types';
+
+interface HourlyForecastWidgetProps {
+  hourlyData: HourlyForecast;
+}
+
+export function HourlyForecastWidget({ hourlyData }: HourlyForecastWidgetProps) {
+  const formatTime = (timeString: string) => {
+    const date = new Date(timeString);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const formatHour = (timeString: string) => {
+    const date = new Date(timeString);
+    const now = new Date();
+    const diffHours = Math.round((date.getTime() - now.getTime()) / (1000 * 60 * 60));
+
+    if (diffHours === 0) return 'Now';
+    if (diffHours === 1) return 'In 1 hour';
+    if (diffHours > 1) return `In ${diffHours} hours`;
+    return formatTime(timeString);
+  };
+
+  const tableItems = hourlyData.time.slice(0, 12).map((time, index) => ({
+    time,
+    hour: formatHour(time),
+    formattedTime: formatTime(time),
+    temperature: Math.round(hourlyData.temperature[index]),
+    humidity: hourlyData.humidity[index],
+    precipitation: hourlyData.precipitation[index],
+    windSpeed: Math.round(hourlyData.windSpeed[index]),
+    weatherCode: hourlyData.weatherCode[index],
+    weatherInfo: WEATHER_CODES[hourlyData.weatherCode[index]] || { description: 'Unknown', icon: '❓' },
+  }));
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Weather forecast for the next 12 hours">
+          Hourly Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: 'Time',
+            cell: item => (
+              <div>
+                <Box variant="strong">{item.hour}</Box>
+                <Box variant="small" color="text-status-inactive">
+                  {item.formattedTime}
+                </Box>
+              </div>
+            ),
+            minWidth: 100,
+          },
+          {
+            id: 'weather',
+            header: 'Condition',
+            cell: item => (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span style={{ fontSize: '1.2em' }}>{item.weatherInfo.icon}</span>
+                <span>{item.weatherInfo.description}</span>
+              </div>
+            ),
+            minWidth: 150,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => `${item.temperature}°C`,
+            minWidth: 80,
+          },
+          {
+            id: 'precipitation',
+            header: 'Rain',
+            cell: item => `${item.precipitation.toFixed(1)} mm`,
+            minWidth: 80,
+          },
+          {
+            id: 'humidity',
+            header: 'Humidity',
+            cell: item => `${item.humidity}%`,
+            minWidth: 80,
+          },
+          {
+            id: 'wind',
+            header: 'Wind',
+            cell: item => `${item.windSpeed} km/h`,
+            minWidth: 80,
+          },
+        ]}
+        items={tableItems}
+        trackBy="time"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No hourly data available</b>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-input-widget.tsx
+++ b/src/pages/weather-dashboard/components/location-input-widget.tsx
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { WeatherLocation } from '../types';
+
+interface LocationInputWidgetProps {
+  onLocationSubmit: (location: WeatherLocation) => void;
+}
+
+export function LocationInputWidget({ onLocationSubmit }: LocationInputWidgetProps) {
+  const [locationName, setLocationName] = useState('');
+  const [latitude, setLatitude] = useState('');
+  const [longitude, setLongitude] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!locationName.trim() || !latitude.trim() || !longitude.trim()) {
+      return;
+    }
+
+    const lat = parseFloat(latitude);
+    const lng = parseFloat(longitude);
+
+    if (isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      onLocationSubmit({
+        name: locationName.trim(),
+        latitude: lat,
+        longitude: lng,
+      });
+      // Clear form after successful submission
+      setLocationName('');
+      setLatitude('');
+      setLongitude('');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isValid =
+    locationName.trim() &&
+    latitude.trim() &&
+    longitude.trim() &&
+    !isNaN(parseFloat(latitude)) &&
+    !isNaN(parseFloat(longitude)) &&
+    parseFloat(latitude) >= -90 &&
+    parseFloat(latitude) <= 90 &&
+    parseFloat(longitude) >= -180 &&
+    parseFloat(longitude) <= 180;
+
+  return (
+    <div>
+      <Box variant="awsui-key-label" margin={{ bottom: 'xs' }}>
+        Custom Location
+      </Box>
+      <SpaceBetween size="s">
+        <FormField label="Location name">
+          <Input
+            value={locationName}
+            onChange={({ detail }) => setLocationName(detail.value)}
+            placeholder="e.g., My Location"
+          />
+        </FormField>
+        <FormField
+          label="Latitude"
+          description="Valid range: -90 to 90"
+          errorText={
+            latitude && (isNaN(parseFloat(latitude)) || parseFloat(latitude) < -90 || parseFloat(latitude) > 90)
+              ? 'Invalid latitude'
+              : undefined
+          }
+        >
+          <Input
+            value={latitude}
+            onChange={({ detail }) => setLatitude(detail.value)}
+            placeholder="e.g., 40.7128"
+            type="number"
+            step="any"
+          />
+        </FormField>
+        <FormField
+          label="Longitude"
+          description="Valid range: -180 to 180"
+          errorText={
+            longitude && (isNaN(parseFloat(longitude)) || parseFloat(longitude) < -180 || parseFloat(longitude) > 180)
+              ? 'Invalid longitude'
+              : undefined
+          }
+        >
+          <Input
+            value={longitude}
+            onChange={({ detail }) => setLongitude(detail.value)}
+            placeholder="e.g., -74.0060"
+            type="number"
+            step="any"
+          />
+        </FormField>
+        <Button variant="primary" onClick={handleSubmit} loading={submitting} disabled={!isValid} fullWidth>
+          Get Weather
+        </Button>
+      </SpaceBetween>
+    </div>
+  );
+}

--- a/src/pages/weather-dashboard/components/temperature-chart-widget.tsx
+++ b/src/pages/weather-dashboard/components/temperature-chart-widget.tsx
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+import Tabs from '@cloudscape-design/components/tabs';
+
+import { DailyForecast, HourlyForecast } from '../types';
+
+interface TemperatureChartWidgetProps {
+  hourlyData: HourlyForecast;
+  dailyData: DailyForecast;
+}
+
+export function TemperatureChartWidget({ hourlyData, dailyData }: TemperatureChartWidgetProps) {
+  const [activeTab, setActiveTab] = useState('hourly');
+
+  const formatHourlyTime = (timeString: string) => {
+    const date = new Date(timeString);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const formatDailyTime = (timeString: string) => {
+    const date = new Date(timeString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    }
+    if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    }
+    return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+  };
+
+  const hourlyChartData = [
+    {
+      title: 'Temperature',
+      type: 'line' as const,
+      data: hourlyData.time.slice(0, 24).map((time, index) => ({
+        x: new Date(time),
+        y: hourlyData.temperature[index],
+      })),
+      valueFormatter: (value: number) => `${Math.round(value)}°C`,
+    },
+  ];
+
+  const dailyChartData = [
+    {
+      title: 'Max Temperature',
+      type: 'line' as const,
+      data: dailyData.time.map((time, index) => ({
+        x: new Date(time),
+        y: dailyData.temperatureMax[index],
+      })),
+      valueFormatter: (value: number) => `${Math.round(value)}°C`,
+    },
+    {
+      title: 'Min Temperature',
+      type: 'line' as const,
+      data: dailyData.time.map((time, index) => ({
+        x: new Date(time),
+        y: dailyData.temperatureMin[index],
+      })),
+      valueFormatter: (value: number) => `${Math.round(value)}°C`,
+    },
+  ];
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Interactive temperature charts">
+          Temperature Trends
+        </Header>
+      }
+    >
+      <Tabs
+        tabs={[
+          {
+            id: 'hourly',
+            label: 'Hourly (24h)',
+            content: (
+              <Box padding={{ vertical: 'm' }}>
+                <LineChart
+                  series={hourlyChartData}
+                  xDomain={[
+                    hourlyData.time[0] ? new Date(hourlyData.time[0]) : new Date(),
+                    hourlyData.time[23] ? new Date(hourlyData.time[23]) : new Date(),
+                  ]}
+                  yDomain={[Math.min(...hourlyData.temperature) - 2, Math.max(...hourlyData.temperature) + 2]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'line chart',
+                    xTickFormatter: formatHourlyTime,
+                  }}
+                  ariaLabel="Hourly temperature chart"
+                  height={300}
+                  hideFilter
+                  hideLegend
+                  xTitle="Time"
+                  yTitle="Temperature (°C)"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                    </Box>
+                  }
+                />
+              </Box>
+            ),
+          },
+          {
+            id: 'daily',
+            label: 'Daily (7 days)',
+            content: (
+              <Box padding={{ vertical: 'm' }}>
+                <LineChart
+                  series={dailyChartData}
+                  xDomain={[
+                    dailyData.time[0] ? new Date(dailyData.time[0]) : new Date(),
+                    dailyData.time[dailyData.time.length - 1]
+                      ? new Date(dailyData.time[dailyData.time.length - 1])
+                      : new Date(),
+                  ]}
+                  yDomain={[Math.min(...dailyData.temperatureMin) - 2, Math.max(...dailyData.temperatureMax) + 2]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'line chart',
+                    xTickFormatter: formatDailyTime,
+                  }}
+                  ariaLabel="Daily temperature chart"
+                  height={300}
+                  hideFilter
+                  xTitle="Date"
+                  yTitle="Temperature (°C)"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                    </Box>
+                  }
+                />
+              </Box>
+            ),
+          },
+        ]}
+        activeTabId={activeTab}
+        onChange={({ detail }) => setActiveTab(detail.activeTabId)}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState, useCallback } from 'react';
+
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import Select from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherApiService } from '../services/weather-api';
+import { WeatherData, WeatherLocation, POPULAR_CITIES } from '../types';
+import { CurrentWeatherWidget } from './current-weather-widget';
+import { DailyForecastWidget } from './daily-forecast-widget';
+import { HourlyForecastWidget } from './hourly-forecast-widget';
+import { LocationInputWidget } from './location-input-widget';
+import { TemperatureChartWidget } from './temperature-chart-widget';
+
+const REFRESH_INTERVAL = 10 * 60 * 1000; // 10 minutes
+
+export function WeatherContent() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedLocation, setSelectedLocation] = useState<WeatherLocation>(POPULAR_CITIES[0]);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [autoLocationLoading, setAutoLocationLoading] = useState(false);
+
+  const fetchWeatherData = useCallback(async (location: WeatherLocation) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await WeatherApiService.fetchWeatherData(location);
+      setWeatherData(data);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch weather data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleLocationChange = useCallback(
+    (location: WeatherLocation) => {
+      setSelectedLocation(location);
+      fetchWeatherData(location);
+    },
+    [fetchWeatherData],
+  );
+
+  const handleUseCurrentLocation = useCallback(async () => {
+    setAutoLocationLoading(true);
+    try {
+      const userLocation = await WeatherApiService.getUserLocation();
+      handleLocationChange(userLocation);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to get current location');
+    } finally {
+      setAutoLocationLoading(false);
+    }
+  }, [handleLocationChange]);
+
+  const handleRefresh = useCallback(() => {
+    fetchWeatherData(selectedLocation);
+  }, [fetchWeatherData, selectedLocation]);
+
+  // Initial data fetch
+  useEffect(() => {
+    fetchWeatherData(selectedLocation);
+  }, [fetchWeatherData, selectedLocation]);
+
+  // Auto-refresh setup
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!loading) {
+        fetchWeatherData(selectedLocation);
+      }
+    }, REFRESH_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, [fetchWeatherData, selectedLocation, loading]);
+
+  const locationSelectOptions = POPULAR_CITIES.map(city => ({
+    label: city.name,
+    value: city.name,
+    city,
+  }));
+
+  if (loading && !weatherData) {
+    return (
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <Spinner size="large" />
+          <Box variant="p" padding={{ top: 'm' }}>
+            Loading weather data...
+          </Box>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error && !weatherData) {
+    return (
+      <Container>
+        <Alert
+          type="error"
+          header="Failed to load weather data"
+          action={
+            <Button onClick={handleRefresh} iconName="refresh">
+              Retry
+            </Button>
+          }
+        >
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      {/* Location Selection */}
+      <Container
+        header={
+          <Header
+            variant="h2"
+            actions={
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button loading={autoLocationLoading} onClick={handleUseCurrentLocation} iconName="status-info">
+                  Use Current Location
+                </Button>
+                <Button loading={loading} onClick={handleRefresh} iconName="refresh">
+                  Refresh
+                </Button>
+              </SpaceBetween>
+            }
+            info={
+              lastUpdated && (
+                <StatusIndicator type="success">Last updated: {lastUpdated.toLocaleTimeString()}</StatusIndicator>
+              )
+            }
+          >
+            Location Settings
+          </Header>
+        }
+      >
+        <ColumnLayout columns={2}>
+          <div>
+            <Box variant="awsui-key-label">Popular Cities</Box>
+            <Select
+              selectedOption={locationSelectOptions.find(option => option.city.name === selectedLocation.name) || null}
+              onChange={({ detail }) => {
+                if (detail.selectedOption?.city) {
+                  handleLocationChange(detail.selectedOption.city);
+                }
+              }}
+              options={locationSelectOptions}
+              placeholder="Select a city"
+              expandToViewport
+            />
+          </div>
+          <LocationInputWidget onLocationSubmit={handleLocationChange} />
+        </ColumnLayout>
+      </Container>
+
+      {error && (
+        <Alert type="warning" dismissible onDismiss={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {weatherData && (
+        <>
+          {/* Current Weather */}
+          <CurrentWeatherWidget weatherData={weatherData} />
+
+          {/* Hourly and Daily Forecasts */}
+          <Grid
+            gridDefinition={[
+              { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+              { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+            ]}
+          >
+            <HourlyForecastWidget hourlyData={weatherData.hourly} />
+            <DailyForecastWidget dailyData={weatherData.daily} />
+          </Grid>
+
+          {/* Temperature Chart */}
+          <TemperatureChartWidget hourlyData={weatherData.hourly} dailyData={weatherData.daily} />
+        </>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-header.tsx
+++ b/src/pages/weather-dashboard/components/weather-header.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import ExpandableSection from '@cloudscape-design/components/expandable-section';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+interface WeatherHeaderProps {
+  actions?: React.ReactNode;
+}
+
+export function WeatherHeader({ actions }: WeatherHeaderProps) {
+  return (
+    <Header
+      variant="h1"
+      description="Real-time weather data and forecasts powered by Open-Meteo Weather API"
+      actions={actions}
+      info={
+        <ExpandableSection headerText="Weather Dashboard Info" variant="footer">
+          <SpaceBetween size="s">
+            <Box variant="p">
+              This weather dashboard provides comprehensive weather information including current conditions, hourly and
+              daily forecasts, and interactive charts. Data is sourced from the Open-Meteo Weather API.
+            </Box>
+            <Box variant="p">
+              <strong>Features:</strong>
+            </Box>
+            <ul>
+              <li>Current weather conditions with real-time updates</li>
+              <li>24-hour hourly forecasts</li>
+              <li>7-day daily forecasts</li>
+              <li>Interactive temperature charts</li>
+              <li>Location selection and search</li>
+              <li>Automatic refresh every 10 minutes</li>
+            </ul>
+          </SpaceBetween>
+        </ExpandableSection>
+      }
+    >
+      Weather Dashboard
+    </Header>
+  );
+}
+
+export function WeatherMainInfo() {
+  return (
+    <SpaceBetween size="s">
+      <Box variant="h2">Weather Dashboard</Box>
+      <StatusIndicator type="success">Data Source: Open-Meteo API</StatusIndicator>
+      <Box variant="p">
+        This dashboard provides comprehensive weather information using the Open-Meteo Weather API. The API provides
+        free access to weather data without requiring an API key.
+      </Box>
+      <Box variant="h3">Available Data</Box>
+      <ul>
+        <li>Current weather conditions</li>
+        <li>Hourly forecasts (24 hours)</li>
+        <li>Daily forecasts (7 days)</li>
+        <li>Temperature, humidity, wind speed</li>
+        <li>Weather conditions and precipitation</li>
+      </ul>
+      <Box variant="h3">Auto-refresh</Box>
+      <Box variant="p">
+        Weather data automatically refreshes every 10 minutes to ensure you have the most current information.
+      </Box>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-side-navigation.tsx
+++ b/src/pages/weather-dashboard/components/weather-side-navigation.tsx
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation, { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
+
+const navigationItems: SideNavigationProps['items'] = [
+  { type: 'link', text: 'Current Weather', href: '#current' },
+  { type: 'link', text: 'Hourly Forecast', href: '#hourly' },
+  { type: 'link', text: 'Daily Forecast', href: '#daily' },
+  { type: 'link', text: 'Charts', href: '#charts' },
+  { type: 'divider' },
+  { type: 'link', text: 'Location Settings', href: '#location' },
+  { type: 'link', text: 'Data Source', href: '#data-source', external: true },
+];
+
+export function WeatherSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#current"
+      header={{
+        href: '#/',
+        text: 'Weather Dashboard',
+      }}
+      items={navigationItems}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/services/weather-api.ts
+++ b/src/pages/weather-dashboard/services/weather-api.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { WeatherApiResponse, WeatherData, WeatherLocation } from '../types';
+
+const BASE_URL = 'https://api.open-meteo.com/v1/forecast';
+
+export class WeatherApiService {
+  static async fetchWeatherData(location: WeatherLocation): Promise<WeatherData> {
+    const params = new URLSearchParams({
+      latitude: location.latitude.toString(),
+      longitude: location.longitude.toString(),
+      current: ['temperature_2m', 'relative_humidity_2m', 'wind_speed_10m', 'wind_direction_10m', 'weather_code'].join(
+        ',',
+      ),
+      hourly: ['temperature_2m', 'relative_humidity_2m', 'precipitation', 'wind_speed_10m', 'weather_code'].join(','),
+      daily: [
+        'temperature_2m_max',
+        'temperature_2m_min',
+        'weather_code',
+        'precipitation_sum',
+        'wind_speed_10m_max',
+      ].join(','),
+      temperature_unit: 'celsius',
+      wind_speed_unit: 'kmh',
+      precipitation_unit: 'mm',
+      timezone: 'auto',
+      forecast_days: '7',
+    });
+
+    const url = `${BASE_URL}?${params.toString()}`;
+
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(`Weather API request failed: ${response.status} ${response.statusText}`);
+      }
+
+      const data: WeatherApiResponse = await response.json();
+
+      return this.transformApiResponse(data, location);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to fetch weather data: ${error.message}`);
+      }
+      throw new Error('Failed to fetch weather data: Unknown error');
+    }
+  }
+
+  private static transformApiResponse(apiData: WeatherApiResponse, location: WeatherLocation): WeatherData {
+    return {
+      current: {
+        temperature: apiData.current.temperature_2m,
+        humidity: apiData.current.relative_humidity_2m,
+        windSpeed: apiData.current.wind_speed_10m,
+        windDirection: apiData.current.wind_direction_10m,
+        weatherCode: apiData.current.weather_code,
+        time: apiData.current.time,
+      },
+      hourly: {
+        time: apiData.hourly.time.slice(0, 24), // Next 24 hours
+        temperature: apiData.hourly.temperature_2m.slice(0, 24),
+        humidity: apiData.hourly.relative_humidity_2m.slice(0, 24),
+        precipitation: apiData.hourly.precipitation.slice(0, 24),
+        windSpeed: apiData.hourly.wind_speed_10m.slice(0, 24),
+        weatherCode: apiData.hourly.weather_code.slice(0, 24),
+      },
+      daily: {
+        time: apiData.daily.time,
+        temperatureMax: apiData.daily.temperature_2m_max,
+        temperatureMin: apiData.daily.temperature_2m_min,
+        weatherCode: apiData.daily.weather_code,
+        precipitation: apiData.daily.precipitation_sum,
+        windSpeed: apiData.daily.wind_speed_10m_max,
+      },
+      location: {
+        ...location,
+        timezone: apiData.timezone,
+      },
+    };
+  }
+
+  static async getUserLocation(): Promise<WeatherLocation> {
+    return new Promise((resolve, reject) => {
+      if (!navigator.geolocation) {
+        reject(new Error('Geolocation is not supported by this browser'));
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          resolve({
+            name: 'Current Location',
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          });
+        },
+        error => {
+          let errorMessage = 'Failed to get location';
+          switch (error.code) {
+            case error.PERMISSION_DENIED:
+              errorMessage = 'Location access denied by user';
+              break;
+            case error.POSITION_UNAVAILABLE:
+              errorMessage = 'Location information unavailable';
+              break;
+            case error.TIMEOUT:
+              errorMessage = 'Location request timed out';
+              break;
+          }
+          reject(new Error(errorMessage));
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 300000, // 5 minutes
+        },
+      );
+    });
+  }
+}

--- a/src/pages/weather-dashboard/types.ts
+++ b/src/pages/weather-dashboard/types.ts
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherLocation {
+  name: string;
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+}
+
+export interface CurrentWeather {
+  temperature: number;
+  humidity: number;
+  windSpeed: number;
+  windDirection: number;
+  weatherCode: number;
+  time: string;
+}
+
+export interface HourlyForecast {
+  time: string[];
+  temperature: number[];
+  humidity: number[];
+  precipitation: number[];
+  windSpeed: number[];
+  weatherCode: number[];
+}
+
+export interface DailyForecast {
+  time: string[];
+  temperatureMax: number[];
+  temperatureMin: number[];
+  weatherCode: number[];
+  precipitation: number[];
+  windSpeed: number[];
+}
+
+export interface WeatherData {
+  current: CurrentWeather;
+  hourly: HourlyForecast;
+  daily: DailyForecast;
+  location: WeatherLocation;
+}
+
+export interface WeatherApiResponse {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    wind_speed_10m: number;
+    wind_direction_10m: number;
+    weather_code: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    relative_humidity_2m: number[];
+    precipitation: number[];
+    wind_speed_10m: number[];
+    weather_code: number[];
+  };
+  daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    weather_code: number[];
+    precipitation_sum: number[];
+    wind_speed_10m_max: number[];
+  };
+}
+
+// Weather code mappings based on WMO Weather interpretation codes
+export const WEATHER_CODES: Record<number, { description: string; icon: string }> = {
+  0: { description: 'Clear sky', icon: '☀️' },
+  1: { description: 'Mainly clear', icon: '🌤️' },
+  2: { description: 'Partly cloudy', icon: '⛅' },
+  3: { description: 'Overcast', icon: '☁️' },
+  45: { description: 'Fog', icon: '🌫️' },
+  48: { description: 'Depositing rime fog', icon: '🌫️' },
+  51: { description: 'Light drizzle', icon: '🌦️' },
+  53: { description: 'Moderate drizzle', icon: '🌦️' },
+  55: { description: 'Dense drizzle', icon: '🌧️' },
+  56: { description: 'Light freezing drizzle', icon: '🌨️' },
+  57: { description: 'Dense freezing drizzle', icon: '🌨️' },
+  61: { description: 'Slight rain', icon: '🌧️' },
+  63: { description: 'Moderate rain', icon: '🌧️' },
+  65: { description: 'Heavy rain', icon: '🌧️' },
+  66: { description: 'Light freezing rain', icon: '🌨️' },
+  67: { description: 'Heavy freezing rain', icon: '🌨️' },
+  71: { description: 'Slight snow fall', icon: '❄️' },
+  73: { description: 'Moderate snow fall', icon: '❄️' },
+  75: { description: 'Heavy snow fall', icon: '❄️' },
+  77: { description: 'Snow grains', icon: '❄️' },
+  80: { description: 'Slight rain showers', icon: '🌦️' },
+  81: { description: 'Moderate rain showers', icon: '🌦️' },
+  82: { description: 'Violent rain showers', icon: '🌧️' },
+  85: { description: 'Slight snow showers', icon: '❄️' },
+  86: { description: 'Heavy snow showers', icon: '❄️' },
+  95: { description: 'Thunderstorm', icon: '⛈️' },
+  96: { description: 'Thunderstorm with slight hail', icon: '⛈️' },
+  99: { description: 'Thunderstorm with heavy hail', icon: '⛈️' },
+};
+
+export const POPULAR_CITIES: WeatherLocation[] = [
+  { name: 'New York, USA', latitude: 40.7128, longitude: -74.006 },
+  { name: 'London, UK', latitude: 51.5074, longitude: -0.1278 },
+  { name: 'Tokyo, Japan', latitude: 35.6762, longitude: 139.6503 },
+  { name: 'Paris, France', latitude: 48.8566, longitude: 2.3522 },
+  { name: 'Sydney, Australia', latitude: -33.8688, longitude: 151.2093 },
+  { name: 'Berlin, Germany', latitude: 52.52, longitude: 13.405 },
+  { name: 'San Francisco, USA', latitude: 37.7749, longitude: -122.4194 },
+  { name: 'Singapore', latitude: 1.3521, longitude: 103.8198 },
+  { name: 'Dubai, UAE', latitude: 25.2048, longitude: 55.2708 },
+  { name: 'São Paulo, Brazil', latitude: -23.5505, longitude: -46.6333 },
+];


### PR DESCRIPTION
Add a comprehensive weather dashboard page with the following components:

- New weather dashboard demo entry in the main demos list
- Main app component with layout, navigation, and tools panel
- Current weather widget displaying temperature, humidity, wind data
- Daily forecast widget with 7-day weather table
- Hourly forecast widget with 24-hour temperature chart
- Temperature trends chart widget with line chart visualization
- Weather header component with location display and actions
- Side navigation with weather-specific menu items
- Weather API service for fetching data from Open-Meteo API
- TypeScript types and interfaces for weather data structures
- Weather code mappings with icons and descriptions
- Popular cities list for location selection

The dashboard includes live weather data, interactive charts, and a responsive layout using Cloudscape Design System components.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/stellar-studio)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>stellar-studio</branchName>-->