### PR TITLE
Add weather dashboard with Open-Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  {
+    route: '/weather',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data using Open-Meteo API.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/weather/app.tsx
+++ b/src/pages/weather/app.tsx
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherContent } from './components/content';
+import { WeatherHeader } from './components/header';
+import { WeatherSideNavigation } from './components/side-navigation';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => (
+    <div>
+      <h3>Weather Dashboard</h3>
+      <p>Monitor weather conditions and forecasts using the Open-Meteo API.</p>
+    </div>
+  ));
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherHeader />
+            <WeatherContent />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/weather' }]} />}
+        navigation={<WeatherSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather/components/content.tsx
+++ b/src/pages/weather/components/content.tsx
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import Select from '@cloudscape-design/components/select';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+import Icon from '@cloudscape-design/components/icon';
+
+import {
+  WeatherResponse,
+  WeatherLocation,
+  DEFAULT_LOCATIONS,
+  getCompleteWeatherData,
+  getWeatherDescription,
+} from '../services/weather-api';
+import { WeatherMetricCard } from './weather-metric-card';
+import { HourlyForecastCard } from './hourly-forecast-card';
+import { DailyForecastCard } from './daily-forecast-card';
+
+export function WeatherContent() {
+  const [selectedLocation, setSelectedLocation] = useState<WeatherLocation>(DEFAULT_LOCATIONS[0]);
+  const [weatherData, setWeatherData] = useState<WeatherResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchWeatherData = async (location: WeatherLocation) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getCompleteWeatherData(location);
+      setWeatherData(data);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch weather data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeatherData(selectedLocation);
+  }, [selectedLocation]);
+
+  const handleLocationChange = (detail: any) => {
+    const location = DEFAULT_LOCATIONS.find(loc => loc.name === detail.selectedOption.value);
+    if (location) {
+      setSelectedLocation(location);
+    }
+  };
+
+  const handleRefresh = () => {
+    fetchWeatherData(selectedLocation);
+  };
+
+  if (loading && !weatherData) {
+    return (
+      <Container>
+        <Box textAlign="center" padding="xxl">
+          <Spinner size="large" />
+          <Box variant="p" padding={{ top: 'm' }}>
+            Loading weather data...
+          </Box>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error && !weatherData) {
+    return (
+      <Container>
+        <Alert
+          statusIconAriaLabel="Error"
+          type="error"
+          header="Failed to load weather data"
+          action={
+            <Button onClick={handleRefresh} iconName="refresh">
+              Try again
+            </Button>
+          }
+        >
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  const currentWeather = weatherData?.current;
+  const weatherInfo = currentWeather ? getWeatherDescription(currentWeather.weatherCode) : null;
+
+  return (
+    <SpaceBetween size="l">
+      {/* Location selector and current conditions header */}
+      <Container
+        header={
+          <Header
+            variant="h2"
+            actions={
+              <SpaceBetween direction="horizontal" size="xs">
+                <Select
+                  selectedOption={{ label: selectedLocation.name, value: selectedLocation.name }}
+                  onChange={({ detail }) => handleLocationChange(detail)}
+                  options={DEFAULT_LOCATIONS.map(location => ({
+                    label: `${location.name}, ${location.country}`,
+                    value: location.name,
+                  }))}
+                  loadingText="Loading locations"
+                  placeholder="Select location"
+                />
+                <Button iconName="refresh" loading={loading} onClick={handleRefresh} ariaLabel="Refresh weather data" />
+              </SpaceBetween>
+            }
+          >
+            Current Weather - {selectedLocation.name}
+            {lastUpdated && (
+              <Box variant="small" color="text-status-info" display="inline" margin={{ left: 's' }}>
+                Updated: {lastUpdated.toLocaleTimeString()}
+              </Box>
+            )}
+          </Header>
+        }
+      >
+        {currentWeather && weatherInfo ? (
+          <Grid
+            gridDefinition={[
+              { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 3, xl: 3 } },
+              { colspan: { default: 12, xs: 12, s: 6, m: 8, l: 9, xl: 9 } },
+            ]}
+          >
+            <Box>
+              <SpaceBetween size="s" alignItems="center">
+                <Box textAlign="center">
+                  <Icon name={weatherInfo.icon} size="big" />
+                </Box>
+                <Box textAlign="center">
+                  <Box fontSize="display-l" fontWeight="bold">
+                    {Math.round(currentWeather.temperature)}°C
+                  </Box>
+                  <Box variant="small" color="text-status-inactive">
+                    {weatherInfo.description}
+                  </Box>
+                  <Badge color={currentWeather.isDay ? 'green' : 'blue'}>
+                    {currentWeather.isDay ? 'Day' : 'Night'}
+                  </Badge>
+                </Box>
+              </SpaceBetween>
+            </Box>
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <SpaceBetween size="s">
+                <WeatherMetricCard label="Humidity" value={`${currentWeather.humidity}%`} icon="percentage" />
+                <WeatherMetricCard
+                  label="Wind Speed"
+                  value={`${Math.round(currentWeather.windSpeed)} km/h`}
+                  icon="arrow-right"
+                />
+              </SpaceBetween>
+              <SpaceBetween size="s">
+                <WeatherMetricCard
+                  label="Pressure"
+                  value={`${Math.round(currentWeather.pressure)} hPa`}
+                  icon="status-info"
+                />
+                <WeatherMetricCard label="Precipitation" value={`${currentWeather.precipitation} mm`} icon="menu" />
+              </SpaceBetween>
+            </Grid>
+          </Grid>
+        ) : (
+          <Box variant="p" color="text-status-inactive">
+            No current weather data available
+          </Box>
+        )}
+      </Container>
+
+      {/* Hourly forecast */}
+      {weatherData?.hourly && <HourlyForecastCard hourlyData={weatherData.hourly} />}
+
+      {/* Daily forecast */}
+      {weatherData?.daily && <DailyForecastCard dailyData={weatherData.daily} />}
+
+      {/* Weather locations grid */}
+      <Container
+        header={
+          <Header variant="h2" description="Quick access to weather data for major cities">
+            Popular Locations
+          </Header>
+        }
+      >
+        <Cards
+          cardDefinition={{
+            header: (item: WeatherLocation) => item.name,
+            sections: [
+              {
+                id: 'country',
+                content: (item: WeatherLocation) => <Badge>{item.country}</Badge>,
+              },
+              {
+                id: 'coordinates',
+                content: (item: WeatherLocation) => (
+                  <Box variant="small" color="text-status-inactive">
+                    {item.latitude.toFixed(2)}°, {item.longitude.toFixed(2)}°
+                  </Box>
+                ),
+              },
+              {
+                id: 'actions',
+                content: (item: WeatherLocation) => (
+                  <Button
+                    variant={item.name === selectedLocation.name ? 'normal' : 'primary'}
+                    disabled={item.name === selectedLocation.name}
+                    onClick={() => setSelectedLocation(item)}
+                    fullWidth
+                  >
+                    {item.name === selectedLocation.name ? 'Current' : 'View Weather'}
+                  </Button>
+                ),
+              },
+            ],
+          }}
+          cardsPerRow={[
+            { cards: 1, minWidth: 0 },
+            { cards: 2, minWidth: 600 },
+            { cards: 3, minWidth: 900 },
+            { cards: 4, minWidth: 1200 },
+          ]}
+          items={DEFAULT_LOCATIONS}
+          trackBy="name"
+          visibleSections={['country', 'coordinates', 'actions']}
+          header={<Header counter={`(${DEFAULT_LOCATIONS.length})`}>Available Locations</Header>}
+        />
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather/components/daily-forecast-card.tsx
+++ b/src/pages/weather/components/daily-forecast-card.tsx
@@ -1,0 +1,191 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Cards from '@cloudscape-design/components/cards';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import Icon from '@cloudscape-design/components/icon';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+
+import { DailyForecast, getWeatherDescription } from '../services/weather-api';
+
+interface DailyForecastCardProps {
+  dailyData: DailyForecast;
+}
+
+interface DailyWeatherItem {
+  date: string;
+  temperatureMax: number;
+  temperatureMin: number;
+  precipitation: number;
+  windSpeedMax: number;
+  weatherCode: number;
+  sunrise: string;
+  sunset: string;
+  uvIndexMax: number;
+}
+
+export function DailyForecastCard({ dailyData }: DailyForecastCardProps) {
+  const dailyItems: DailyWeatherItem[] = dailyData.time.map((date, index) => ({
+    date,
+    temperatureMax: dailyData.temperatureMax[index],
+    temperatureMin: dailyData.temperatureMin[index],
+    precipitation: dailyData.precipitation[index],
+    windSpeedMax: dailyData.windSpeedMax[index],
+    weatherCode: dailyData.weatherCode[index],
+    sunrise: dailyData.sunrise[index],
+    sunset: dailyData.sunset[index],
+    uvIndexMax: dailyData.uvIndexMax[index],
+  }));
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    } else {
+      return date.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+    }
+  };
+
+  const formatTime = (timeString: string) => {
+    const time = new Date(timeString);
+    return time.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  const getUvIndexBadge = (uvIndex: number) => {
+    if (uvIndex <= 2) return { color: 'green' as const, text: 'Low' };
+    if (uvIndex <= 5) return { color: 'blue' as const, text: 'Moderate' };
+    if (uvIndex <= 7) return { color: 'grey' as const, text: 'High' };
+    if (uvIndex <= 10) return { color: 'red' as const, text: 'Very High' };
+    return { color: 'red' as const, text: 'Extreme' };
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="7-day weather forecast with detailed conditions">
+          Daily Forecast
+        </Header>
+      }
+    >
+      <Cards
+        cardDefinition={{
+          header: (item: DailyWeatherItem) => (
+            <Box>
+              <Box fontWeight="bold">{formatDate(item.date)}</Box>
+              <Box variant="small" color="text-status-inactive">
+                {new Date(item.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}
+              </Box>
+            </Box>
+          ),
+          sections: [
+            {
+              id: 'weather',
+              content: (item: DailyWeatherItem) => {
+                const weather = getWeatherDescription(item.weatherCode);
+                return (
+                  <SpaceBetween size="s" alignItems="center">
+                    <Box textAlign="center">
+                      <Icon name={weather.icon} size="normal" />
+                    </Box>
+                    <Box textAlign="center" variant="small">
+                      {weather.description}
+                    </Box>
+                  </SpaceBetween>
+                );
+              },
+            },
+            {
+              id: 'temperature',
+              content: (item: DailyWeatherItem) => (
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <Box textAlign="center">
+                    <Box fontSize="heading-s" fontWeight="bold" color="text-status-error">
+                      {Math.round(item.temperatureMax)}°
+                    </Box>
+                    <Box variant="small" color="text-status-inactive">
+                      High
+                    </Box>
+                  </Box>
+                  <Box textAlign="center">
+                    <Box fontSize="heading-s" fontWeight="bold" color="text-status-info">
+                      {Math.round(item.temperatureMin)}°
+                    </Box>
+                    <Box variant="small" color="text-status-inactive">
+                      Low
+                    </Box>
+                  </Box>
+                </Grid>
+              ),
+            },
+            {
+              id: 'details',
+              content: (item: DailyWeatherItem) => (
+                <SpaceBetween size="xs">
+                  <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                    <Box variant="small">
+                      <Icon name="menu" size="small" /> {item.precipitation.toFixed(1)} mm
+                    </Box>
+                    <Box variant="small">
+                      <Icon name="arrow-right" size="small" /> {Math.round(item.windSpeedMax)} km/h
+                    </Box>
+                  </Grid>
+                  <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                    <Box variant="small">
+                      <Icon name="status-positive" size="small" /> {formatTime(item.sunrise)}
+                    </Box>
+                    <Box variant="small">
+                      <Icon name="status-negative" size="small" /> {formatTime(item.sunset)}
+                    </Box>
+                  </Grid>
+                  {item.uvIndexMax > 0 && (
+                    <Box textAlign="center">
+                      <Badge color={getUvIndexBadge(item.uvIndexMax).color}>
+                        UV: {Math.round(item.uvIndexMax)} - {getUvIndexBadge(item.uvIndexMax).text}
+                      </Badge>
+                    </Box>
+                  )}
+                </SpaceBetween>
+              ),
+            },
+          ],
+        }}
+        cardsPerRow={[
+          { cards: 1, minWidth: 0 },
+          { cards: 2, minWidth: 500 },
+          { cards: 3, minWidth: 768 },
+          { cards: 4, minWidth: 1024 },
+          { cards: 7, minWidth: 1400 },
+        ]}
+        items={dailyItems}
+        trackBy="date"
+        visibleSections={['weather', 'temperature', 'details']}
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="p" color="inherit">
+              No daily forecast data available
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather/components/header.tsx
+++ b/src/pages/weather/components/header.tsx
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+export function WeatherHeader() {
+  return (
+    <Header
+      variant="h1"
+      description="Real-time weather data and forecasts powered by Open-Meteo API"
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button iconName="refresh" onClick={() => window.location.reload()}>
+            Refresh
+          </Button>
+          <Button
+            variant="primary"
+            iconName="external"
+            iconAlign="right"
+            onClick={() => window.open('https://open-meteo.com', '_blank')}
+          >
+            Open-Meteo API
+          </Button>
+        </SpaceBetween>
+      }
+    >
+      Weather Dashboard
+    </Header>
+  );
+}

--- a/src/pages/weather/components/hourly-forecast-card.tsx
+++ b/src/pages/weather/components/hourly-forecast-card.tsx
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import Icon from '@cloudscape-design/components/icon';
+
+import { HourlyForecast, getWeatherDescription } from '../services/weather-api';
+
+interface HourlyForecastCardProps {
+  hourlyData: HourlyForecast;
+}
+
+export function HourlyForecastCard({ hourlyData }: HourlyForecastCardProps) {
+  // Show next 24 hours
+  const next24Hours = hourlyData.time.slice(0, 24).map((time, index) => ({
+    time,
+    temperature: hourlyData.temperature[index],
+    precipitation: hourlyData.precipitation[index],
+    windSpeed: hourlyData.windSpeed[index],
+    humidity: hourlyData.humidity[index],
+    weatherCode: hourlyData.weatherCode[index],
+  }));
+
+  const formatTime = (timeString: string) => {
+    const date = new Date(timeString);
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      hour12: true,
+    });
+  };
+
+  const formatDate = (timeString: string) => {
+    const date = new Date(timeString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    } else {
+      return date.toLocaleDateString('en-US', { weekday: 'short' });
+    }
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Detailed hourly weather forecast for the next 24 hours">
+          Hourly Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: 'Time',
+            cell: item => (
+              <Box>
+                <Box fontWeight="bold">{formatTime(item.time)}</Box>
+                <Box variant="small" color="text-status-inactive">
+                  {formatDate(item.time)}
+                </Box>
+              </Box>
+            ),
+            width: 100,
+          },
+          {
+            id: 'condition',
+            header: 'Condition',
+            cell: item => {
+              const weather = getWeatherDescription(item.weatherCode);
+              return (
+                <Box>
+                  <Icon name={weather.icon} /> {weather.description}
+                </Box>
+              );
+            },
+            width: 150,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => <Box fontWeight="bold">{Math.round(item.temperature)}°C</Box>,
+            width: 100,
+          },
+          {
+            id: 'precipitation',
+            header: 'Rain',
+            cell: item => (
+              <Box>
+                {item.precipitation > 0 ? (
+                  <Badge color="blue">{item.precipitation.toFixed(1)} mm</Badge>
+                ) : (
+                  <Box color="text-status-inactive">0 mm</Box>
+                )}
+              </Box>
+            ),
+            width: 80,
+          },
+          {
+            id: 'wind',
+            header: 'Wind',
+            cell: item => `${Math.round(item.windSpeed)} km/h`,
+            width: 80,
+          },
+          {
+            id: 'humidity',
+            header: 'Humidity',
+            cell: item => `${Math.round(item.humidity)}%`,
+            width: 80,
+          },
+        ]}
+        items={next24Hours}
+        loadingText="Loading forecast"
+        trackBy="time"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="p" color="inherit">
+              No hourly forecast data available
+            </Box>
+          </Box>
+        }
+        stripedRows
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather/components/side-navigation.tsx
+++ b/src/pages/weather/components/side-navigation.tsx
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+export function WeatherSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#current"
+      header={{ href: '#/', text: 'Weather Dashboard' }}
+      items={[
+        { type: 'link', text: 'Current Weather', href: '#current' },
+        { type: 'link', text: 'Hourly Forecast', href: '#hourly' },
+        { type: 'link', text: 'Daily Forecast', href: '#daily' },
+        { type: 'divider' },
+        { type: 'link', text: 'Locations', href: '#locations' },
+        { type: 'link', text: 'Settings', href: '#settings' },
+      ]}
+    />
+  );
+}

--- a/src/pages/weather/components/weather-metric-card.tsx
+++ b/src/pages/weather/components/weather-metric-card.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Icon from '@cloudscape-design/components/icon';
+
+interface WeatherMetricCardProps {
+  label: string;
+  value: string;
+  icon: string;
+  trend?: 'up' | 'down' | 'stable';
+}
+
+export function WeatherMetricCard({ label, value, icon, trend }: WeatherMetricCardProps) {
+  const getTrendIcon = (trend?: string) => {
+    switch (trend) {
+      case 'up':
+        return 'angle-up';
+      case 'down':
+        return 'angle-down';
+      default:
+        return null;
+    }
+  };
+
+  const getTrendColor = (trend?: string) => {
+    switch (trend) {
+      case 'up':
+        return 'text-status-success';
+      case 'down':
+        return 'text-status-error';
+      default:
+        return 'text-status-inactive';
+    }
+  };
+
+  return (
+    <Box padding="s" className="weather-metric-card">
+      <SpaceBetween direction="horizontal" size="s" alignItems="center">
+        <Icon name={icon} variant="subtle" />
+        <SpaceBetween size="xxs">
+          <Box variant="small" color="text-status-inactive">
+            {label}
+          </Box>
+          <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+            <Box fontWeight="bold">{value}</Box>
+            {trend && getTrendIcon(trend) && <Icon name={getTrendIcon(trend)!} size="small" variant="subtle" />}
+          </SpaceBetween>
+        </SpaceBetween>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/pages/weather/index.tsx
+++ b/src/pages/weather/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather/services/weather-api.ts
+++ b/src/pages/weather/services/weather-api.ts
@@ -1,0 +1,268 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherLocation {
+  latitude: number;
+  longitude: number;
+  name: string;
+  country?: string;
+  timezone?: string;
+}
+
+export interface CurrentWeather {
+  temperature: number;
+  windSpeed: number;
+  windDirection: number;
+  humidity: number;
+  pressure: number;
+  precipitation: number;
+  cloudCover: number;
+  visibility: number;
+  uvIndex: number;
+  weatherCode: number;
+  isDay: boolean;
+  time: string;
+}
+
+export interface HourlyForecast {
+  time: string[];
+  temperature: number[];
+  precipitation: number[];
+  windSpeed: number[];
+  humidity: number[];
+  pressure: number[];
+  cloudCover: number[];
+  weatherCode: number[];
+}
+
+export interface DailyForecast {
+  time: string[];
+  temperatureMax: number[];
+  temperatureMin: number[];
+  precipitation: number[];
+  windSpeedMax: number[];
+  windDirection: number[];
+  weatherCode: number[];
+  sunrise: string[];
+  sunset: string[];
+  uvIndexMax: number[];
+}
+
+export interface WeatherResponse {
+  current?: CurrentWeather;
+  hourly?: HourlyForecast;
+  daily?: DailyForecast;
+  location: WeatherLocation;
+}
+
+const API_BASE_URL = 'https://api.open-meteo.com/v1';
+
+// Weather code mappings based on WMO standards
+export const WEATHER_CODES: Record<number, { description: string; icon: string }> = {
+  0: { description: 'Clear sky', icon: 'sun' },
+  1: { description: 'Mainly clear', icon: 'sun' },
+  2: { description: 'Partly cloudy', icon: 'cloud-sun' },
+  3: { description: 'Overcast', icon: 'cloud' },
+  45: { description: 'Fog', icon: 'cloud' },
+  48: { description: 'Depositing rime fog', icon: 'cloud' },
+  51: { description: 'Light drizzle', icon: 'cloud-drizzle' },
+  53: { description: 'Moderate drizzle', icon: 'cloud-drizzle' },
+  55: { description: 'Dense drizzle', icon: 'cloud-rain' },
+  61: { description: 'Slight rain', icon: 'cloud-rain' },
+  63: { description: 'Moderate rain', icon: 'cloud-rain' },
+  65: { description: 'Heavy rain', icon: 'cloud-rain' },
+  71: { description: 'Slight snow', icon: 'cloud-snow' },
+  73: { description: 'Moderate snow', icon: 'cloud-snow' },
+  75: { description: 'Heavy snow', icon: 'cloud-snow' },
+  80: { description: 'Slight rain showers', icon: 'cloud-rain' },
+  81: { description: 'Moderate rain showers', icon: 'cloud-rain' },
+  82: { description: 'Violent rain showers', icon: 'cloud-rain' },
+  95: { description: 'Thunderstorm', icon: 'cloud-lightning' },
+  96: { description: 'Thunderstorm with hail', icon: 'cloud-lightning' },
+  99: { description: 'Thunderstorm with heavy hail', icon: 'cloud-lightning' },
+};
+
+export function getWeatherDescription(code: number): { description: string; icon: string } {
+  return WEATHER_CODES[code] || { description: 'Unknown', icon: 'question' };
+}
+
+export async function getCurrentWeather(location: WeatherLocation): Promise<CurrentWeather> {
+  const params = new URLSearchParams({
+    latitude: location.latitude.toString(),
+    longitude: location.longitude.toString(),
+    current: [
+      'temperature_2m',
+      'relative_humidity_2m',
+      'apparent_temperature',
+      'is_day',
+      'precipitation',
+      'rain',
+      'showers',
+      'snowfall',
+      'weather_code',
+      'cloud_cover',
+      'pressure_msl',
+      'surface_pressure',
+      'wind_speed_10m',
+      'wind_direction_10m',
+      'wind_gusts_10m',
+    ].join(','),
+    temperature_unit: 'celsius',
+    wind_speed_unit: 'kmh',
+    precipitation_unit: 'mm',
+    timezone: 'auto',
+  });
+
+  const response = await fetch(`${API_BASE_URL}/forecast?${params}`);
+  if (!response.ok) {
+    throw new Error(`Weather API error: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const current = data.current;
+
+  return {
+    temperature: current.temperature_2m,
+    windSpeed: current.wind_speed_10m,
+    windDirection: current.wind_direction_10m,
+    humidity: current.relative_humidity_2m,
+    pressure: current.pressure_msl,
+    precipitation: current.precipitation,
+    cloudCover: current.cloud_cover,
+    visibility: 10000, // Open-Meteo doesn't provide visibility, using default
+    uvIndex: 0, // Will need separate UV API call
+    weatherCode: current.weather_code,
+    isDay: current.is_day === 1,
+    time: current.time,
+  };
+}
+
+export async function getHourlyForecast(location: WeatherLocation, days: number = 1): Promise<HourlyForecast> {
+  const params = new URLSearchParams({
+    latitude: location.latitude.toString(),
+    longitude: location.longitude.toString(),
+    hourly: [
+      'temperature_2m',
+      'relative_humidity_2m',
+      'precipitation_probability',
+      'precipitation',
+      'rain',
+      'showers',
+      'snowfall',
+      'weather_code',
+      'pressure_msl',
+      'cloud_cover',
+      'wind_speed_10m',
+      'wind_direction_10m',
+      'wind_gusts_10m',
+      'uv_index',
+    ].join(','),
+    temperature_unit: 'celsius',
+    wind_speed_unit: 'kmh',
+    precipitation_unit: 'mm',
+    timezone: 'auto',
+    forecast_days: days.toString(),
+  });
+
+  const response = await fetch(`${API_BASE_URL}/forecast?${params}`);
+  if (!response.ok) {
+    throw new Error(`Weather API error: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const hourly = data.hourly;
+
+  return {
+    time: hourly.time,
+    temperature: hourly.temperature_2m,
+    precipitation: hourly.precipitation,
+    windSpeed: hourly.wind_speed_10m,
+    humidity: hourly.relative_humidity_2m,
+    pressure: hourly.pressure_msl,
+    cloudCover: hourly.cloud_cover,
+    weatherCode: hourly.weather_code,
+  };
+}
+
+export async function getDailyForecast(location: WeatherLocation, days: number = 7): Promise<DailyForecast> {
+  const params = new URLSearchParams({
+    latitude: location.latitude.toString(),
+    longitude: location.longitude.toString(),
+    daily: [
+      'weather_code',
+      'temperature_2m_max',
+      'temperature_2m_min',
+      'apparent_temperature_max',
+      'apparent_temperature_min',
+      'sunrise',
+      'sunset',
+      'uv_index_max',
+      'precipitation_sum',
+      'rain_sum',
+      'showers_sum',
+      'snowfall_sum',
+      'precipitation_hours',
+      'precipitation_probability_max',
+      'wind_speed_10m_max',
+      'wind_gusts_10m_max',
+      'wind_direction_10m_dominant',
+    ].join(','),
+    temperature_unit: 'celsius',
+    wind_speed_unit: 'kmh',
+    precipitation_unit: 'mm',
+    timezone: 'auto',
+    forecast_days: days.toString(),
+  });
+
+  const response = await fetch(`${API_BASE_URL}/forecast?${params}`);
+  if (!response.ok) {
+    throw new Error(`Weather API error: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const daily = data.daily;
+
+  return {
+    time: daily.time,
+    temperatureMax: daily.temperature_2m_max,
+    temperatureMin: daily.temperature_2m_min,
+    precipitation: daily.precipitation_sum,
+    windSpeedMax: daily.wind_speed_10m_max,
+    windDirection: daily.wind_direction_10m_dominant,
+    weatherCode: daily.weather_code,
+    sunrise: daily.sunrise,
+    sunset: daily.sunset,
+    uvIndexMax: daily.uv_index_max,
+  };
+}
+
+export async function getCompleteWeatherData(location: WeatherLocation): Promise<WeatherResponse> {
+  try {
+    const [current, hourly, daily] = await Promise.all([
+      getCurrentWeather(location),
+      getHourlyForecast(location, 2),
+      getDailyForecast(location, 7),
+    ]);
+
+    return {
+      current,
+      hourly,
+      daily,
+      location,
+    };
+  } catch (error) {
+    console.error('Error fetching weather data:', error);
+    throw error;
+  }
+}
+
+// Predefined locations for demo purposes
+export const DEFAULT_LOCATIONS: WeatherLocation[] = [
+  { latitude: 40.7128, longitude: -74.006, name: 'New York', country: 'US' },
+  { latitude: 51.5074, longitude: -0.1278, name: 'London', country: 'UK' },
+  { latitude: 48.8566, longitude: 2.3522, name: 'Paris', country: 'FR' },
+  { latitude: 35.6762, longitude: 139.6503, name: 'Tokyo', country: 'JP' },
+  { latitude: -33.8688, longitude: 151.2093, name: 'Sydney', country: 'AU' },
+  { latitude: 52.52, longitude: 13.405, name: 'Berlin', country: 'DE' },
+  { latitude: 37.7749, longitude: -122.4194, name: 'San Francisco', country: 'US' },
+];


### PR DESCRIPTION
This pull request adds a new weather dashboard feature to the application.

Changes include:
- Added weather dashboard route to the demos list in index.tsx
- Created new weather dashboard page with main app component
- Implemented weather content component with current conditions display
- Added weather metric cards for humidity, wind speed, pressure, and precipitation
- Created hourly and daily forecast card components
- Integrated Open-Meteo API service for fetching weather data
- Added support for multiple predefined locations (New York, London, Paris, Tokyo, Sydney, Berlin, San Francisco)
- Implemented location selector and refresh functionality
- Added proper error handling and loading states
- Included weather code mappings for condition descriptions and icons

The dashboard displays:
- Current weather conditions with temperature, weather description, and day/night indicator
- Key weather metrics in card format
- Hourly forecast data
- Daily forecast data
- Quick access to weather for major cities

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/zenith-field)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-zenith-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>zenith-field</branchName>-->