### PR TITLE
feat: Add Administration Dashboard page

### DIFF
--- a/src/pages/administration-dashboard/app.tsx
+++ b/src/pages/administration-dashboard/app.tsx
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import Pagination from '@cloudscape-design/components/pagination';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+import { ChartSection } from './chart-section';
+import { DataTable } from './data-table';
+
+export function App() {
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [filteringText, setFilteringText] = useState('');
+
+  return (
+    <>
+      <TopNavigation
+        identity={{
+          href: '#/',
+          title: 'Service name',
+          logo: {
+            src: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"%3E%3Crect width="16" height="16" fill="%23232F3E"/%3E%3C/svg%3E',
+            alt: 'Service Logo',
+          },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            text: 'Link',
+            href: '#/',
+            external: true,
+            externalIconAriaLabel: ' (opens in a new tab)',
+          },
+          {
+            type: 'button',
+            iconName: 'notification',
+            title: 'Notifications',
+            ariaLabel: 'Notifications (unread)',
+            badge: true,
+            disableUtilityCollapse: false,
+          },
+          {
+            type: 'button',
+            iconName: 'settings',
+            title: 'Settings',
+            ariaLabel: 'Settings',
+          },
+          {
+            type: 'menu-dropdown',
+            text: 'Customer name',
+            description: 'customer@example.com',
+            iconName: 'user-profile',
+            items: [
+              { id: 'profile', text: 'Profile' },
+              { id: 'preferences', text: 'Preferences' },
+              { id: 'security', text: 'Security' },
+              {
+                id: 'support-group',
+                text: 'Support',
+                items: [
+                  {
+                    id: 'documentation',
+                    text: 'Documentation',
+                    href: '#/',
+                    external: true,
+                    externalIconAriaLabel: ' (opens in new tab)',
+                  },
+                  { id: 'support', text: 'Support' },
+                ],
+              },
+              { id: 'signout', text: 'Sign out' },
+            ],
+          },
+        ]}
+        i18nStrings={{
+          searchIconAriaLabel: 'Search',
+          searchDismissIconAriaLabel: 'Close search',
+          overflowMenuTriggerText: 'More',
+          overflowMenuTitleText: 'All',
+          overflowMenuBackIconAriaLabel: 'Back',
+          overflowMenuDismissIconAriaLabel: 'Close menu',
+        }}
+      />
+
+      <AppLayout
+        navigationHide
+        toolsHide
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#/' },
+              { text: 'Administrative Dashboard', href: '#/administration-dashboard' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+        }
+        content={
+          <SpaceBetween size="l">
+            <Header
+              variant="h1"
+              description="Collection description"
+              actions={
+                <Button variant="primary" iconAlign="right" iconName="external">
+                  Refresh Data
+                </Button>
+              }
+            >
+              Administration Dashboard
+            </Header>
+
+            <Container>
+              <Grid
+                gridDefinition={[
+                  { colspan: { default: 12, xxs: 12, xs: 8 } },
+                  { colspan: { default: 12, xxs: 12, xs: 4 } },
+                ]}
+              >
+                <TextFilter
+                  filteringText={filteringText}
+                  filteringPlaceholder="Placeholder"
+                  filteringAriaLabel="Filter data"
+                  onChange={({ detail }) => setFilteringText(detail.filteringText)}
+                />
+                <Box float="right">
+                  <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+                    <Pagination
+                      currentPageIndex={currentPageIndex}
+                      onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                      pagesCount={5}
+                      ariaLabels={{
+                        nextPageLabel: 'Next page',
+                        previousPageLabel: 'Previous page',
+                        pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+                      }}
+                    />
+                    <Button iconName="settings" variant="icon" ariaLabel="Settings" />
+                  </SpaceBetween>
+                </Box>
+              </Grid>
+            </Container>
+
+            <ChartSection />
+
+            <DataTable />
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/src/pages/administration-dashboard/app.tsx
+++ b/src/pages/administration-dashboard/app.tsx
@@ -116,7 +116,7 @@ export function App() {
                 </Button>
               }
             >
-              Administration Dashboard
+              Adminstration Dashboard
             </Header>
 
             <Container>

--- a/src/pages/administration-dashboard/chart-section.tsx
+++ b/src/pages/administration-dashboard/chart-section.tsx
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+
+export function ChartSection() {
+  return (
+    <ColumnLayout columns={2} variant="text-grid">
+      <Container fitHeight>
+        <AreaChart
+          series={[
+            {
+              title: 'Site 1',
+              type: 'area',
+              data: [
+                { x: new Date(1601596800000), y: 25 },
+                { x: new Date(1604275200000), y: 28 },
+                { x: new Date(1606867200000), y: 30 },
+                { x: new Date(1609545600000), y: 32 },
+                { x: new Date(1612224000000), y: 35 },
+                { x: new Date(1614643200000), y: 38 },
+                { x: new Date(1617321600000), y: 42 },
+                { x: new Date(1619913600000), y: 45 },
+                { x: new Date(1622592000000), y: 48 },
+                { x: new Date(1625184000000), y: 50 },
+                { x: new Date(1627862400000), y: 52 },
+                { x: new Date(1630540800000), y: 55 },
+              ],
+            },
+            {
+              title: 'Site 2',
+              type: 'area',
+              data: [
+                { x: new Date(1601596800000), y: 15 },
+                { x: new Date(1604275200000), y: 18 },
+                { x: new Date(1606867200000), y: 22 },
+                { x: new Date(1609545600000), y: 25 },
+                { x: new Date(1612224000000), y: 28 },
+                { x: new Date(1614643200000), y: 30 },
+                { x: new Date(1617321600000), y: 32 },
+                { x: new Date(1619913600000), y: 35 },
+                { x: new Date(1622592000000), y: 38 },
+                { x: new Date(1625184000000), y: 40 },
+                { x: new Date(1627862400000), y: 42 },
+                { x: new Date(1630540800000), y: 45 },
+              ],
+            },
+          ]}
+          xScaleType="time"
+          yTitle="y-axis label"
+          xTitle="X-axis label"
+          ariaLabel="Area chart"
+          height={300}
+          hideFilter
+          hideLegend={false}
+          statusType="finished"
+          i18nStrings={{
+            filterLabel: 'Filter displayed data',
+            filterPlaceholder: 'Filter data',
+            filterSelectedAriaLabel: 'selected',
+            legendAriaLabel: 'Legend',
+            chartAriaRoleDescription: 'area chart',
+            xTickFormatter: e =>
+              e
+                .toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  hour12: false,
+                })
+                .split(',')
+                .join('\n'),
+            yTickFormatter: undefined,
+          }}
+        />
+      </Container>
+
+      <Container fitHeight>
+        <BarChart
+          series={[
+            {
+              title: 'Site 1',
+              type: 'bar',
+              data: [
+                { x: 'x1', y: 35 },
+                { x: 'x2', y: 50 },
+                { x: 'x3', y: 42 },
+                { x: 'x4', y: 25 },
+                { x: 'x5', y: 41 },
+              ],
+            },
+          ]}
+          xScaleType="categorical"
+          yTitle="y-axis label"
+          xTitle="X-axis label"
+          ariaLabel="Bar chart"
+          height={300}
+          hideFilter
+          hideLegend={false}
+          statusType="finished"
+          i18nStrings={{
+            filterLabel: 'Filter displayed data',
+            filterPlaceholder: 'Filter data',
+            filterSelectedAriaLabel: 'selected',
+            legendAriaLabel: 'Legend',
+            chartAriaRoleDescription: 'bar chart',
+            xTickFormatter: e => e,
+            yTickFormatter: undefined,
+          }}
+        />
+      </Container>
+    </ColumnLayout>
+  );
+}

--- a/src/pages/administration-dashboard/chart-section.tsx
+++ b/src/pages/administration-dashboard/chart-section.tsx
@@ -10,7 +10,7 @@ import Container from '@cloudscape-design/components/container';
 
 export function ChartSection() {
   return (
-    <ColumnLayout columns={2} variant="text-grid">
+    <ColumnLayout columns={2} variant="text-grid" className="admin-dashboard-charts">
       <Container fitHeight>
         <AreaChart
           series={[

--- a/src/pages/administration-dashboard/data-table.tsx
+++ b/src/pages/administration-dashboard/data-table.tsx
@@ -40,7 +40,8 @@ export function DataTable() {
   const items = generateTableData();
 
   return (
-    <Table
+    <div className="admin-dashboard-table">
+      <Table
       columnDefinitions={[
         {
           id: 'column1',
@@ -109,6 +110,7 @@ export function DataTable() {
       }}
       variant="full-page"
       stickyHeader
-    />
+      />
+    </div>
   );
 }

--- a/src/pages/administration-dashboard/data-table.tsx
+++ b/src/pages/administration-dashboard/data-table.tsx
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Table from '@cloudscape-design/components/table';
+import Header from '@cloudscape-design/components/header';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+interface TableItem {
+  id: string;
+  column1: string;
+  column2: string;
+  column3: string;
+  column4: string;
+  column5: string;
+  column6: string;
+  column7: string;
+}
+
+const generateTableData = (): TableItem[] => {
+  const data: TableItem[] = [];
+  for (let i = 1; i <= 12; i++) {
+    data.push({
+      id: `row-${i}`,
+      column1: 'Cell Value',
+      column2: 'Cell Value',
+      column3: 'Cell Value',
+      column4: 'Cell Value',
+      column5: 'Cell Value',
+      column6: 'Cell Value',
+      column7: 'Cell Value',
+    });
+  }
+  return data;
+};
+
+export function DataTable() {
+  const [selectedItems, setSelectedItems] = useState<TableItem[]>([]);
+  const items = generateTableData();
+
+  return (
+    <Table
+      columnDefinitions={[
+        {
+          id: 'column1',
+          header: 'Column header',
+          cell: item => item.column1,
+          sortingField: 'column1',
+        },
+        {
+          id: 'column2',
+          header: 'Column header',
+          cell: item => item.column2,
+          sortingField: 'column2',
+        },
+        {
+          id: 'column3',
+          header: 'Column header',
+          cell: item => item.column3,
+          sortingField: 'column3',
+        },
+        {
+          id: 'column4',
+          header: 'Column header',
+          cell: item => item.column4,
+          sortingField: 'column4',
+        },
+        {
+          id: 'column5',
+          header: 'Column header',
+          cell: item => item.column5,
+          sortingField: 'column5',
+        },
+        {
+          id: 'column6',
+          header: 'Column header',
+          cell: item => item.column6,
+          sortingField: 'column6',
+        },
+        {
+          id: 'column7',
+          header: 'Column header',
+          cell: item => item.column7,
+          sortingField: 'column7',
+        },
+      ]}
+      items={items}
+      loadingText="Loading resources"
+      selectionType="multi"
+      trackBy="id"
+      empty={
+        <Box textAlign="center" color="inherit">
+          <b>No resources</b>
+          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+            No resources to display.
+          </Box>
+        </Box>
+      }
+      selectedItems={selectedItems}
+      onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+      ariaLabels={{
+        selectionGroupLabel: 'Items selection',
+        allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+        itemSelectionLabel: ({ selectedItems }, item) => {
+          const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
+          return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
+        },
+      }}
+      variant="full-page"
+      stickyHeader
+    />
+  );
+}

--- a/src/pages/administration-dashboard/data-table.tsx
+++ b/src/pages/administration-dashboard/data-table.tsx
@@ -42,74 +42,75 @@ export function DataTable() {
   return (
     <div className="admin-dashboard-table">
       <Table
-      columnDefinitions={[
-        {
-          id: 'column1',
-          header: 'Column header',
-          cell: item => item.column1,
-          sortingField: 'column1',
-        },
-        {
-          id: 'column2',
-          header: 'Column header',
-          cell: item => item.column2,
-          sortingField: 'column2',
-        },
-        {
-          id: 'column3',
-          header: 'Column header',
-          cell: item => item.column3,
-          sortingField: 'column3',
-        },
-        {
-          id: 'column4',
-          header: 'Column header',
-          cell: item => item.column4,
-          sortingField: 'column4',
-        },
-        {
-          id: 'column5',
-          header: 'Column header',
-          cell: item => item.column5,
-          sortingField: 'column5',
-        },
-        {
-          id: 'column6',
-          header: 'Column header',
-          cell: item => item.column6,
-          sortingField: 'column6',
-        },
-        {
-          id: 'column7',
-          header: 'Column header',
-          cell: item => item.column7,
-          sortingField: 'column7',
-        },
-      ]}
-      items={items}
-      loadingText="Loading resources"
-      selectionType="multi"
-      trackBy="id"
-      empty={
-        <Box textAlign="center" color="inherit">
-          <b>No resources</b>
-          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
-            No resources to display.
+        columnDefinitions={[
+          {
+            id: 'column1',
+            header: 'Column header',
+            cell: item => item.column1,
+            sortingField: 'column1',
+          },
+          {
+            id: 'column2',
+            header: 'Column header',
+            cell: item => item.column2,
+            sortingField: 'column2',
+          },
+          {
+            id: 'column3',
+            header: 'Column header',
+            cell: item => item.column3,
+            sortingField: 'column3',
+          },
+          {
+            id: 'column4',
+            header: 'Column header',
+            cell: item => item.column4,
+            sortingField: 'column4',
+          },
+          {
+            id: 'column5',
+            header: 'Column header',
+            cell: item => item.column5,
+            sortingField: 'column5',
+          },
+          {
+            id: 'column6',
+            header: 'Column header',
+            cell: item => item.column6,
+            sortingField: 'column6',
+          },
+          {
+            id: 'column7',
+            header: 'Column header',
+            cell: item => item.column7,
+            sortingField: 'column7',
+          },
+        ]}
+        items={items}
+        loadingText="Loading resources"
+        selectionType="multi"
+        trackBy="id"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No resources</b>
+            <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+              No resources to display.
+            </Box>
           </Box>
-        </Box>
-      }
-      selectedItems={selectedItems}
-      onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
-      ariaLabels={{
-        selectionGroupLabel: 'Items selection',
-        allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-        itemSelectionLabel: ({ selectedItems }, item) => {
-          const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
-          return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
-        },
-      }}
-      variant="full-page"
-      stickyHeader
+        }
+        selectedItems={selectedItems}
+        onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+        ariaLabels={{
+          selectionGroupLabel: 'Items selection',
+          allItemsSelectionLabel: ({ selectedItems }) =>
+            `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+          itemSelectionLabel: ({ selectedItems }, item) => {
+            const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
+            return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
+          },
+        }}
+        variant="full-page"
+        stickyHeader
       />
     </div>
   );

--- a/src/pages/administration-dashboard/index.tsx
+++ b/src/pages/administration-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function AdministrationDashboard() {
+  return <App />;
+}

--- a/src/pages/administration-dashboard/index.tsx
+++ b/src/pages/administration-dashboard/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { App } from './app';
 
 import '../../styles/base.scss';
+import '../../styles/administration-dashboard.scss';
 
 export default function AdministrationDashboard() {
   return <App />;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,12 @@ import Link from '@cloudscape-design/components/link';
 
 // Demo definitions with category information
 const demos = [
+  {
+    route: '/administration-dashboard',
+    title: 'Administration Dashboard',
+    description: 'Administration dashboard with charts and data table.',
+    category: 'Dashboards',
+  },
   { route: '/cards', title: 'Card View', description: 'Demo of Cloudscape Cards component.', category: 'Components' },
   { route: '/chat', title: 'Chat', description: 'Chat UI demo.', category: 'Applications' },
   {

--- a/src/styles/administration-dashboard.scss
+++ b/src/styles/administration-dashboard.scss
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.admin-dashboard-charts {
+  .awsui-util-container {
+    height: 100%;
+  }
+}
+
+.admin-dashboard-table {
+  .awsui-table-variant-full-page {
+    border-top: none;
+  }
+}


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal was to implement a new Administration Dashboard. This dashboard is designed to provide a comprehensive overview of administrative data, featuring data visualization through charts and a detailed tabular view of resources. The implementation should be responsive and adhere to modern CSS practices.

### Code changes

- **New Page**: Added a new `AdministrationDashboard` page located at `/administration-dashboard`.
- **Components**:
    - Created `app.tsx` to serve as the main layout for the dashboard, including header, breadcrumbs, and action buttons.
    - Implemented `chart-section.tsx` which displays an `AreaChart` and a `BarChart` for data visualization.
    - Added `data-table.tsx` to present data in a paginated and filterable table.
- **Styling**: Introduced new SCSS styles in `administration-dashboard.scss` to ensure the components are styled correctly.
- **Routing**: Updated `src/pages/index.tsx` to include the new dashboard in the list of available demos.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/echo-den)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-echo-den.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>echo-den</branchName>-->