### PR TITLE
feat: Add maintenance mode banner to dashboards

### DIFF
--- a/src/pages/configurable-dashboard/app.tsx
+++ b/src/pages/configurable-dashboard/app.tsx
@@ -46,7 +46,18 @@ export function App() {
         toolsOpen={toolsOpen}
         tools={toolsContent}
         onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-        notifications={<Notifications />}
+        notifications={
+          <Notifications
+            customNotifications={[
+              {
+                type: 'warning',
+                content: 'This dashboard is currently in maintenance mode. Some features may be temporarily unavailable.',
+                dismissible: true,
+                id: 'dashboard-alert',
+              },
+            ]}
+          />
+        }
         content={
           <Content
             layout={filteredLayout ?? null}

--- a/src/pages/dashboard/app.tsx
+++ b/src/pages/dashboard/app.tsx
@@ -40,7 +40,18 @@ export function App() {
         tools={toolsContent}
         toolsOpen={toolsOpen}
         onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-        notifications={<Notifications />}
+        notifications={
+          <Notifications
+            customNotifications={[
+              {
+                type: 'warning',
+                content: 'This dashboard is currently in maintenance mode. Some features may be temporarily unavailable.',
+                dismissible: true,
+                id: 'dashboard-alert',
+              },
+            ]}
+          />
+        }
       />
     </HelpPanelProvider>
   );


### PR DESCRIPTION
### Purpose

Based on the user's request, this change adds a dismissible alert banner to the top of the dashboards to inform users that the application is in maintenance mode.

### Code changes

- Added a `customNotifications` prop to the `Notifications` component on the following pages:
    - `src/pages/configurable-dashboard/app.tsx`
    - `src/pages/dashboard/app.tsx`
- The new notification is a warning-level alert that informs users about the dashboard's maintenance mode and its potential impact on feature availability.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/flare-realm)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-flare-realm.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>flare-realm</branchName>-->