### PR TITLE
Implement responsive Administration Dashboard page

### DIFF
--- a/src/pages/administration-dashboard/app.tsx
+++ b/src/pages/administration-dashboard/app.tsx
@@ -163,167 +163,164 @@ export function App() {
               Adminstration Dashboard
             </Header>
 
-            <SpaceBetween size="m">
-              <div className="search-pagination-wrapper" style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                <div style={{ flex: 1 }}>
-                  <Input
-                    value=""
-                    type="search"
-                    placeholder="Placeholder"
-                    ariaLabel="Search"
-                  />
-                </div>
-                <Pagination
-                  currentPageIndex={currentPageIndex}
-                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
-                  pagesCount={5}
-                />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+              <div style={{ flex: 1 }}>
+                <Input value="" type="search" placeholder="Placeholder" ariaLabel="Search" />
               </div>
-
-              <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-                <div style={{ flex: '1 1 400px', minWidth: '400px' }}>
-                  <Container>
-                    <AreaChart
-                      series={areaChartData}
-                      xDomain={['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12']}
-                      yDomain={[0, 7]}
-                      i18nStrings={{
-                        filterLabel: 'Filter displayed data',
-                        filterPlaceholder: 'Filter data',
-                        filterSelectedAriaLabel: 'selected',
-                        legendAriaLabel: 'Legend',
-                        chartAriaRoleDescription: 'area chart',
-                        xAxisAriaRoleDescription: 'x axis',
-                        yAxisAriaRoleDescription: 'y axis',
-                      }}
-                      ariaLabel="Area chart"
-                      height={300}
-                      xTitle="X-axis label"
-                      yTitle="y-axis label"
-                      empty={
-                        <Box textAlign="center" color="inherit">
-                          <b>No data available</b>
-                          <Box variant="p" color="inherit">
-                            There is no data available
-                          </Box>
-                        </Box>
-                      }
-                      noMatch={
-                        <Box textAlign="center" color="inherit">
-                          <b>No matching data</b>
-                          <Box variant="p" color="inherit">
-                            There is no matching data to display
-                          </Box>
-                        </Box>
-                      }
-                    />
-                  </Container>
-                </div>
-
-                <div style={{ flex: '1 1 400px', minWidth: '400px' }}>
-                  <Container>
-                    <BarChart
-                      series={[
-                        {
-                          title: 'Site 1',
-                          type: 'bar',
-                          data: barChartData,
-                        },
-                      ]}
-                      xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
-                      yDomain={[0, 300]}
-                      i18nStrings={{
-                        filterLabel: 'Filter displayed data',
-                        filterPlaceholder: 'Filter data',
-                        filterSelectedAriaLabel: 'selected',
-                        legendAriaLabel: 'Legend',
-                        chartAriaRoleDescription: 'bar chart',
-                        xAxisAriaRoleDescription: 'x axis',
-                        yAxisAriaRoleDescription: 'y axis',
-                      }}
-                      ariaLabel="Bar chart"
-                      height={300}
-                      xTitle="X-axis label"
-                      yTitle="y-axis label"
-                      empty={
-                        <Box textAlign="center" color="inherit">
-                          <b>No data available</b>
-                          <Box variant="p" color="inherit">
-                            There is no data available
-                          </Box>
-                        </Box>
-                      }
-                      noMatch={
-                        <Box textAlign="center" color="inherit">
-                          <b>No matching data</b>
-                          <Box variant="p" color="inherit">
-                            There is no matching data to display
-                          </Box>
-                        </Box>
-                      }
-                    />
-                  </Container>
-                </div>
-              </div>
-
-              <Table
-                columnDefinitions={[
-                  {
-                    id: 'column1',
-                    header: 'Column header',
-                    cell: item => item.column1,
-                    sortingField: 'column1',
-                  },
-                  {
-                    id: 'column2',
-                    header: 'Column header',
-                    cell: item => item.column2,
-                    sortingField: 'column2',
-                  },
-                  {
-                    id: 'column3',
-                    header: 'Column header',
-                    cell: item => item.column3,
-                    sortingField: 'column3',
-                  },
-                  {
-                    id: 'column4',
-                    header: 'Column header',
-                    cell: item => item.column4,
-                    sortingField: 'column4',
-                  },
-                  {
-                    id: 'column5',
-                    header: 'Column header',
-                    cell: item => item.column5,
-                    sortingField: 'column5',
-                  },
-                  {
-                    id: 'column6',
-                    header: 'Column header',
-                    cell: item => item.column6,
-                    sortingField: 'column6',
-                  },
-                  {
-                    id: 'column7',
-                    header: 'Column header',
-                    cell: item => item.column7,
-                    sortingField: 'column7',
-                  },
-                ]}
-                items={tableItems}
-                selectionType="multi"
-                selectedItems={selectedItems}
-                onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
-                ariaLabels={{
-                  selectionGroupLabel: 'Items selection',
-                  allItemsSelectionLabel: () => 'select all',
-                  itemSelectionLabel: (data, row) => `select ${row.id}`,
-                }}
-                variant="full-page"
-                stickyHeader
+              <Pagination
+                currentPageIndex={currentPageIndex}
+                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                pagesCount={5}
               />
-            </SpaceBetween>
+            </div>
+
+            <ColumnLayout columns={2} variant="default">
+              <Container header={<Box variant="h3">y-axis label</Box>}>
+                <SpaceBetween size="s">
+                  <AreaChart
+                    series={areaChartData}
+                    xDomain={['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12']}
+                    yDomain={[0, 7]}
+                    i18nStrings={{
+                      filterLabel: 'Filter displayed data',
+                      filterPlaceholder: 'Filter data',
+                      filterSelectedAriaLabel: 'selected',
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'area chart',
+                      xAxisAriaRoleDescription: 'x axis',
+                      yAxisAriaRoleDescription: 'y axis',
+                    }}
+                    ariaLabel="Area chart"
+                    height={300}
+                    xTitle="X-axis label"
+                    yTitle=""
+                    hideFilter
+                    hideLegend={false}
+                    empty={
+                      <Box textAlign="center" color="inherit">
+                        <b>No data available</b>
+                        <Box variant="p" color="inherit">
+                          There is no data available
+                        </Box>
+                      </Box>
+                    }
+                    noMatch={
+                      <Box textAlign="center" color="inherit">
+                        <b>No matching data</b>
+                        <Box variant="p" color="inherit">
+                          There is no matching data to display
+                        </Box>
+                      </Box>
+                    }
+                  />
+                </SpaceBetween>
+              </Container>
+
+              <Container header={<Box variant="h3">y-axis label</Box>}>
+                <SpaceBetween size="s">
+                  <BarChart
+                    series={[
+                      {
+                        title: 'Site 1',
+                        type: 'bar',
+                        data: barChartData,
+                      },
+                    ]}
+                    xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                    yDomain={[0, 300]}
+                    i18nStrings={{
+                      filterLabel: 'Filter displayed data',
+                      filterPlaceholder: 'Filter data',
+                      filterSelectedAriaLabel: 'selected',
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'bar chart',
+                      xAxisAriaRoleDescription: 'x axis',
+                      yAxisAriaRoleDescription: 'y axis',
+                    }}
+                    ariaLabel="Bar chart"
+                    height={300}
+                    xTitle="X-axis label"
+                    yTitle=""
+                    hideFilter
+                    hideLegend={false}
+                    empty={
+                      <Box textAlign="center" color="inherit">
+                        <b>No data available</b>
+                        <Box variant="p" color="inherit">
+                          There is no data available
+                        </Box>
+                      </Box>
+                    }
+                    noMatch={
+                      <Box textAlign="center" color="inherit">
+                        <b>No matching data</b>
+                        <Box variant="p" color="inherit">
+                          There is no matching data to display
+                        </Box>
+                      </Box>
+                    }
+                  />
+                </SpaceBetween>
+              </Container>
+            </ColumnLayout>
+
+            <Table
+              columnDefinitions={[
+                {
+                  id: 'column1',
+                  header: 'Column header',
+                  cell: item => item.column1,
+                  sortingField: 'column1',
+                },
+                {
+                  id: 'column2',
+                  header: 'Column header',
+                  cell: item => item.column2,
+                  sortingField: 'column2',
+                },
+                {
+                  id: 'column3',
+                  header: 'Column header',
+                  cell: item => item.column3,
+                  sortingField: 'column3',
+                },
+                {
+                  id: 'column4',
+                  header: 'Column header',
+                  cell: item => item.column4,
+                  sortingField: 'column4',
+                },
+                {
+                  id: 'column5',
+                  header: 'Column header',
+                  cell: item => item.column5,
+                  sortingField: 'column5',
+                },
+                {
+                  id: 'column6',
+                  header: 'Column header',
+                  cell: item => item.column6,
+                  sortingField: 'column6',
+                },
+                {
+                  id: 'column7',
+                  header: 'Column header',
+                  cell: item => item.column7,
+                  sortingField: 'column7',
+                },
+              ]}
+              items={tableItems}
+              selectionType="multi"
+              selectedItems={selectedItems}
+              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+              ariaLabels={{
+                selectionGroupLabel: 'Items selection',
+                allItemsSelectionLabel: () => 'select all',
+                itemSelectionLabel: (data, row) => `select ${row.id}`,
+              }}
+              variant="full-page"
+              stickyHeader
+            />
           </SpaceBetween>
         }
       />

--- a/src/pages/administration-dashboard/app.tsx
+++ b/src/pages/administration-dashboard/app.tsx
@@ -1,0 +1,332 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Input from '@cloudscape-design/components/input';
+import Pagination from '@cloudscape-design/components/pagination';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Box from '@cloudscape-design/components/box';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Table from '@cloudscape-design/components/table';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+// Mock data for charts
+const areaChartData = [
+  {
+    title: 'Site 1',
+    type: 'area',
+    data: [
+      { x: 'x1', y: 2 },
+      { x: 'x2', y: 3 },
+      { x: 'x3', y: 4 },
+      { x: 'x4', y: 5 },
+      { x: 'x5', y: 5 },
+      { x: 'x6', y: 6 },
+      { x: 'x7', y: 4 },
+      { x: 'x8', y: 3 },
+      { x: 'x9', y: 2 },
+      { x: 'x10', y: 3 },
+      { x: 'x11', y: 4 },
+      { x: 'x12', y: 3 },
+    ],
+  },
+  {
+    title: 'Site 2',
+    type: 'area',
+    data: [
+      { x: 'x1', y: 3 },
+      { x: 'x2', y: 4 },
+      { x: 'x3', y: 5 },
+      { x: 'x4', y: 4 },
+      { x: 'x5', y: 3 },
+      { x: 'x6', y: 5 },
+      { x: 'x7', y: 6 },
+      { x: 'x8', y: 5 },
+      { x: 'x9', y: 4 },
+      { x: 'x10', y: 5 },
+      { x: 'x11', y: 6 },
+      { x: 'x12', y: 4 },
+    ],
+  },
+];
+
+const barChartData = [
+  { x: 'x1', y: 183 },
+  { x: 'x2', y: 257 },
+  { x: 'x3', y: 213 },
+  { x: 'x4', y: 122 },
+  { x: 'x5', y: 210 },
+];
+
+// Mock data for table
+const tableItems = Array.from({ length: 12 }, (_, index) => ({
+  id: index + 1,
+  column1: 'Cell Value',
+  column2: 'Cell Value',
+  column3: 'Cell Value',
+  column4: 'Cell Value',
+  column5: 'Cell Value',
+  column6: 'Cell Value',
+  column7: 'Cell Value',
+}));
+
+export function App() {
+  const [searchValue, setSearchValue] = useState('');
+  const [selectedItems, setSelectedItems] = useState([]);
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+
+  return (
+    <>
+      <TopNavigation
+        identity={{
+          href: '#',
+          title: 'Service name',
+          logo: { src: '', alt: 'Logo' },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            text: 'Link',
+            href: '#',
+            external: true,
+            externalIconAriaLabel: ' (opens in a new tab)',
+          },
+          {
+            type: 'button',
+            iconName: 'notification',
+            ariaLabel: 'Notifications',
+            badge: true,
+          },
+          {
+            type: 'button',
+            iconName: 'settings',
+            title: 'Settings',
+            ariaLabel: 'Settings',
+          },
+          {
+            type: 'menu-dropdown',
+            text: 'Customer name',
+            iconName: 'user-profile',
+            items: [
+              { id: 'profile', text: 'Profile' },
+              { id: 'preferences', text: 'Preferences' },
+              { id: 'security', text: 'Security' },
+              {
+                id: 'signout',
+                text: 'Sign out',
+              },
+            ],
+          },
+        ]}
+        search={
+          <Input
+            ariaLabel="Search"
+            clearAriaLabel="Clear"
+            value={searchValue}
+            type="search"
+            placeholder="Search"
+            onChange={({ detail }) => setSearchValue(detail.value)}
+          />
+        }
+      />
+
+      <AppLayout
+        navigationHide
+        toolsHide
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#' },
+              { text: 'Administrative Dashboard', href: '#' },
+            ]}
+          />
+        }
+        content={
+          <SpaceBetween size="l">
+            <Header
+              variant="h1"
+              description="Collection description"
+              actions={
+                <Button variant="primary" iconAlign="right" iconName="external">
+                  Refresh Data
+                </Button>
+              }
+            >
+              Adminstration Dashboard
+            </Header>
+
+            <SpaceBetween size="m">
+              <div className="search-pagination-wrapper" style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                <div style={{ flex: 1 }}>
+                  <Input
+                    value=""
+                    type="search"
+                    placeholder="Placeholder"
+                    ariaLabel="Search"
+                  />
+                </div>
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                  pagesCount={5}
+                />
+              </div>
+
+              <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+                <div style={{ flex: '1 1 400px', minWidth: '400px' }}>
+                  <Container>
+                    <AreaChart
+                      series={areaChartData}
+                      xDomain={['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12']}
+                      yDomain={[0, 7]}
+                      i18nStrings={{
+                        filterLabel: 'Filter displayed data',
+                        filterPlaceholder: 'Filter data',
+                        filterSelectedAriaLabel: 'selected',
+                        legendAriaLabel: 'Legend',
+                        chartAriaRoleDescription: 'area chart',
+                        xAxisAriaRoleDescription: 'x axis',
+                        yAxisAriaRoleDescription: 'y axis',
+                      }}
+                      ariaLabel="Area chart"
+                      height={300}
+                      xTitle="X-axis label"
+                      yTitle="y-axis label"
+                      empty={
+                        <Box textAlign="center" color="inherit">
+                          <b>No data available</b>
+                          <Box variant="p" color="inherit">
+                            There is no data available
+                          </Box>
+                        </Box>
+                      }
+                      noMatch={
+                        <Box textAlign="center" color="inherit">
+                          <b>No matching data</b>
+                          <Box variant="p" color="inherit">
+                            There is no matching data to display
+                          </Box>
+                        </Box>
+                      }
+                    />
+                  </Container>
+                </div>
+
+                <div style={{ flex: '1 1 400px', minWidth: '400px' }}>
+                  <Container>
+                    <BarChart
+                      series={[
+                        {
+                          title: 'Site 1',
+                          type: 'bar',
+                          data: barChartData,
+                        },
+                      ]}
+                      xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                      yDomain={[0, 300]}
+                      i18nStrings={{
+                        filterLabel: 'Filter displayed data',
+                        filterPlaceholder: 'Filter data',
+                        filterSelectedAriaLabel: 'selected',
+                        legendAriaLabel: 'Legend',
+                        chartAriaRoleDescription: 'bar chart',
+                        xAxisAriaRoleDescription: 'x axis',
+                        yAxisAriaRoleDescription: 'y axis',
+                      }}
+                      ariaLabel="Bar chart"
+                      height={300}
+                      xTitle="X-axis label"
+                      yTitle="y-axis label"
+                      empty={
+                        <Box textAlign="center" color="inherit">
+                          <b>No data available</b>
+                          <Box variant="p" color="inherit">
+                            There is no data available
+                          </Box>
+                        </Box>
+                      }
+                      noMatch={
+                        <Box textAlign="center" color="inherit">
+                          <b>No matching data</b>
+                          <Box variant="p" color="inherit">
+                            There is no matching data to display
+                          </Box>
+                        </Box>
+                      }
+                    />
+                  </Container>
+                </div>
+              </div>
+
+              <Table
+                columnDefinitions={[
+                  {
+                    id: 'column1',
+                    header: 'Column header',
+                    cell: item => item.column1,
+                    sortingField: 'column1',
+                  },
+                  {
+                    id: 'column2',
+                    header: 'Column header',
+                    cell: item => item.column2,
+                    sortingField: 'column2',
+                  },
+                  {
+                    id: 'column3',
+                    header: 'Column header',
+                    cell: item => item.column3,
+                    sortingField: 'column3',
+                  },
+                  {
+                    id: 'column4',
+                    header: 'Column header',
+                    cell: item => item.column4,
+                    sortingField: 'column4',
+                  },
+                  {
+                    id: 'column5',
+                    header: 'Column header',
+                    cell: item => item.column5,
+                    sortingField: 'column5',
+                  },
+                  {
+                    id: 'column6',
+                    header: 'Column header',
+                    cell: item => item.column6,
+                    sortingField: 'column6',
+                  },
+                  {
+                    id: 'column7',
+                    header: 'Column header',
+                    cell: item => item.column7,
+                    sortingField: 'column7',
+                  },
+                ]}
+                items={tableItems}
+                selectionType="multi"
+                selectedItems={selectedItems}
+                onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+                ariaLabels={{
+                  selectionGroupLabel: 'Items selection',
+                  allItemsSelectionLabel: () => 'select all',
+                  itemSelectionLabel: (data, row) => `select ${row.id}`,
+                }}
+                variant="full-page"
+                stickyHeader
+              />
+            </SpaceBetween>
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/src/pages/administration-dashboard/index.tsx
+++ b/src/pages/administration-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function AdministrationDashboard() {
+  return <App />;
+}

--- a/src/pages/administration-dashboard/root.tsx
+++ b/src/pages/administration-dashboard/root.tsx
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import AdministrationDashboard from './index';
+
+export default function Root() {
+  return <AdministrationDashboard />;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/administration-dashboard',
+    title: 'Administration Dashboard',
+    description: 'Administration dashboard with charts and data table.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',


### PR DESCRIPTION
## Summary
This PR implements a new Administration Dashboard page using Cloudscape components, featuring responsive charts and a data table as specified in the design requirements.

## Problem
The application was missing the Administration Dashboard view outlined in the recent design specifications, which required converting raw design references into a functional, responsive UI.

## Solution
Implemented a new page using the Cloudscape Design System to ensure responsiveness and consistency. The layout includes top navigation, summary charts (Area and Bar), and a detailed data table using mock data.

## Key Changes
*   **New Dashboard Page**: Created `AdministrationDashboard` utilizing `AppLayout`, `TopNavigation`, and `ColumnLayout`.
*   **Data Visualization**: Implemented `AreaChart` and `BarChart` components with mock data series.
*   **Tabular Data**: Added a sortable `Table` component with multi-selection capabilities.
*   **Routing**: Registered the new route `/administration-dashboard` in the main application index.

## Files Changed
*   `src/pages/administration-dashboard/app.tsx`: Created main dashboard logic, mock data, and layout structure.
*   `src/pages/administration-dashboard/index.tsx`: Added page entry point.
*   `src/pages/index.tsx`: Registered the new dashboard in the demos list.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/zen-zone)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-zen-zone.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>zen-zone</branchName>-->