### PR TITLE
Implement administrative dashboard page

### DIFF
--- a/src/pages/administrative-dashboard/app.tsx
+++ b/src/pages/administrative-dashboard/app.tsx
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import Input from '@cloudscape-design/components/input';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Badge from '@cloudscape-design/components/badge';
+import { DashboardContent } from './components/content';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [searchValue, setSearchValue] = useState('');
+  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [toolsOpen, setToolsOpen] = useState(false);
+
+  return (
+    <>
+      <TopNavigation
+        identity={{
+          href: '#/',
+          title: 'Service name',
+          logo: {
+            src: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDMiIGhlaWdodD0iMzEiIHZpZXdCb3g9IjAgMCA0MyAzMSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iNDMiIGhlaWdodD0iMzEiIHJ4PSIyIiBmaWxsPSIjMjMyRjNFIi8+CiAgPHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJPcGVuIFNhbnMsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTQiIGZpbGw9IiNGQkZCRkIiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIj5Mb2dvPC90ZXh0Pgo8L3N2Zz4=',
+            alt: 'Logo',
+          },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            iconName: 'external',
+            title: 'Link',
+            text: 'Link',
+            href: '#',
+            external: true,
+            externalIconAriaLabel: ' (opens in new tab)',
+          },
+          {
+            type: 'button',
+            iconName: 'notification',
+            title: 'Notifications',
+            ariaLabel: 'Notifications (unread)',
+            badge: true,
+            disableUtilityCollapse: false,
+          },
+          {
+            type: 'button',
+            iconName: 'settings',
+            title: 'Settings',
+            ariaLabel: 'Settings',
+          },
+          {
+            type: 'menu-dropdown',
+            text: 'Customer name',
+            description: 'Customer name',
+            iconName: 'user-profile',
+            items: [
+              { id: 'profile', text: 'Profile' },
+              { id: 'preferences', text: 'Preferences' },
+              { id: 'security', text: 'Security' },
+              {
+                id: 'support-group',
+                text: 'Support',
+                items: [
+                  {
+                    id: 'documentation',
+                    text: 'Documentation',
+                    href: '#',
+                    external: true,
+                    externalIconAriaLabel: ' (opens in new tab)',
+                  },
+                  { id: 'support', text: 'Support' },
+                ],
+              },
+              { id: 'signout', text: 'Sign out' },
+            ],
+          },
+        ]}
+        i18nStrings={{
+          searchIconAriaLabel: 'Search',
+          searchDismissIconAriaLabel: 'Close search',
+          overflowMenuTriggerText: 'More',
+          overflowMenuTitleText: 'All',
+          overflowMenuBackIconAriaLabel: 'Back',
+          overflowMenuDismissIconAriaLabel: 'Close menu',
+        }}
+      />
+      <AppLayout
+        contentType="table"
+        navigationHide={true}
+        toolsHide={true}
+        navigationOpen={navigationOpen}
+        onNavigationChange={({ detail }) => setNavigationOpen(detail.open)}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#/' },
+              { text: 'Administrative Dashboard', href: '#/administrative-dashboard' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+        }
+        content={<DashboardContent />}
+        ariaLabels={{
+          navigation: 'Side navigation',
+          navigationClose: 'Close side navigation',
+          navigationToggle: 'Open side navigation',
+          tools: 'Help panel',
+          toolsClose: 'Close help panel',
+          toolsToggle: 'Open help panel',
+        }}
+      />
+    </>
+  );
+}

--- a/src/pages/administrative-dashboard/components/content.tsx
+++ b/src/pages/administrative-dashboard/components/content.tsx
@@ -1,0 +1,276 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Container from '@cloudscape-design/components/container';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+// Sample data for the table
+const generateTableData = () => {
+  const data = [];
+  for (let i = 1; i <= 50; i++) {
+    data.push({
+      id: `item-${i}`,
+      col1: `Cell Value ${i}`,
+      col2: `Cell Value ${i}`,
+      col3: `Cell Value ${i}`,
+      col4: `Cell Value ${i}`,
+      col5: `Cell Value ${i}`,
+      col6: `Cell Value ${i}`,
+      col7: `Cell Value ${i}`,
+    });
+  }
+  return data;
+};
+
+const allTableItems = generateTableData();
+
+// Area chart data
+const areaSeries = [
+  {
+    title: 'Site 1',
+    type: 'area' as const,
+    data: [
+      { x: 'x1', y: 2 },
+      { x: 'x2', y: 3 },
+      { x: 'x3', y: 3.5 },
+      { x: 'x4', y: 4 },
+      { x: 'x5', y: 4.5 },
+      { x: 'x6', y: 5 },
+      { x: 'x7', y: 5.5 },
+      { x: 'x8', y: 5 },
+      { x: 'x9', y: 4.5 },
+      { x: 'x10', y: 3.5 },
+      { x: 'x11', y: 3 },
+      { x: 'x12', y: 2.5 },
+    ],
+    valueFormatter: (value: number) => `y${value}`,
+  },
+  {
+    title: 'Site 2',
+    type: 'area' as const,
+    data: [
+      { x: 'x1', y: 1.5 },
+      { x: 'x2', y: 2 },
+      { x: 'x3', y: 2.8 },
+      { x: 'x4', y: 3.2 },
+      { x: 'x5', y: 3.8 },
+      { x: 'x6', y: 4.2 },
+      { x: 'x7', y: 4.5 },
+      { x: 'x8', y: 4.8 },
+      { x: 'x9', y: 5.2 },
+      { x: 'x10', y: 5.5 },
+      { x: 'x11', y: 5.8 },
+      { x: 'x12', y: 6 },
+    ],
+    valueFormatter: (value: number) => `y${value}`,
+  },
+  {
+    title: 'Performance goal',
+    type: 'threshold' as const,
+    y: 3.5,
+    valueFormatter: (value: number) => `y${value}`,
+  },
+];
+
+// Bar chart data
+const barSeries = [
+  {
+    title: 'Site 1',
+    type: 'bar' as const,
+    data: [
+      { x: 'x1', y: 3.5 },
+      { x: 'x2', y: 5 },
+      { x: 'x3', y: 4 },
+      { x: 'x4', y: 2.5 },
+      { x: 'x5', y: 4 },
+    ],
+  },
+  {
+    title: 'Performance goal',
+    type: 'threshold' as const,
+    y: 3.5,
+  },
+];
+
+export function DashboardContent() {
+  const [selectedItems, setSelectedItems] = useState<any[]>([]);
+
+  // Table columns
+  const columnDefinitions = [
+    {
+      id: 'col1',
+      header: 'Column header',
+      cell: (item: any) => item.col1,
+      sortingField: 'col1',
+    },
+    {
+      id: 'col2',
+      header: 'Column header',
+      cell: (item: any) => item.col2,
+      sortingField: 'col2',
+    },
+    {
+      id: 'col3',
+      header: 'Column header',
+      cell: (item: any) => item.col3,
+      sortingField: 'col3',
+    },
+    {
+      id: 'col4',
+      header: 'Column header',
+      cell: (item: any) => item.col4,
+      sortingField: 'col4',
+    },
+    {
+      id: 'col5',
+      header: 'Column header',
+      cell: (item: any) => item.col5,
+      sortingField: 'col5',
+    },
+    {
+      id: 'col6',
+      header: 'Column header',
+      cell: (item: any) => item.col6,
+      sortingField: 'col6',
+    },
+    {
+      id: 'col7',
+      header: 'Column header',
+      cell: (item: any) => item.col7,
+      sortingField: 'col7',
+    },
+  ];
+
+  // Use collection hooks for filtering, pagination, and sorting
+  const { items, collectionProps, filterProps, paginationProps, filteredItemsCount } = useCollection(allTableItems, {
+    filtering: {
+      empty: (
+        <Box textAlign="center" color="inherit">
+          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+            <b>No items</b>
+          </Box>
+        </Box>
+      ),
+      noMatch: (
+        <Box textAlign="center" color="inherit">
+          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+            <b>No matches</b>
+          </Box>
+        </Box>
+      ),
+    },
+    pagination: { pageSize: 10 },
+    sorting: {},
+    selection: {},
+  });
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="Collection description"
+        actions={
+          <Button variant="primary" iconName="external" iconAlign="right">
+            Refresh Data
+          </Button>
+        }
+      >
+        Adminstration Dashboard
+      </Header>
+
+      {/* Charts Section */}
+      <ColumnLayout columns={2} variant="default">
+        <Container>
+          <AreaChart
+            series={areaSeries}
+            height={300}
+            xScaleType="categorical"
+            yScaleType="linear"
+            xTitle="X-axis label"
+            yTitle="y-axis label"
+            ariaLabel="Area chart showing site performance"
+            legendTitle="Legend"
+            hideFilter
+            i18nStrings={{
+              filterLabel: 'Filter displayed data',
+              filterPlaceholder: 'Filter data',
+              filterSelectedAriaLabel: 'selected',
+              legendAriaLabel: 'Legend',
+              chartAriaRoleDescription: 'area chart',
+              xAxisAriaRoleDescription: 'x axis',
+              yAxisAriaRoleDescription: 'y axis',
+            }}
+          />
+        </Container>
+
+        <Container>
+          <BarChart
+            series={barSeries}
+            height={300}
+            xScaleType="categorical"
+            yScaleType="linear"
+            xTitle="X-axis label"
+            yTitle="y-axis label"
+            ariaLabel="Bar chart showing site performance"
+            legendTitle="Legend"
+            hideFilter
+            i18nStrings={{
+              filterLabel: 'Filter displayed data',
+              filterPlaceholder: 'Filter data',
+              filterSelectedAriaLabel: 'selected',
+              legendAriaLabel: 'Legend',
+              chartAriaRoleDescription: 'bar chart',
+              xAxisAriaRoleDescription: 'x axis',
+              yAxisAriaRoleDescription: 'y axis',
+            }}
+          />
+        </Container>
+      </ColumnLayout>
+
+      {/* Table Section */}
+      <Table
+        {...collectionProps}
+        selectionType="multi"
+        selectedItems={selectedItems}
+        onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+        columnDefinitions={columnDefinitions}
+        items={items}
+        trackBy="id"
+        header={
+          <Header variant="h2" counter={`(${allTableItems.length})`}>
+            Data Table
+          </Header>
+        }
+        filter={
+          <TextFilter
+            {...filterProps}
+            filteringPlaceholder="Placeholder"
+            filteringAriaLabel="Filter items"
+            countText={`${filteredItemsCount} ${filteredItemsCount === 1 ? 'match' : 'matches'}`}
+          />
+        }
+        pagination={<Pagination {...paginationProps} ariaLabels={{ nextPageLabel: 'Next page', previousPageLabel: 'Previous page', pageLabel: (pageNumber) => `Page ${pageNumber}` }} />}
+        ariaLabels={{
+          selectionGroupLabel: 'Items selection',
+          allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+          itemSelectionLabel: ({ selectedItems }, item) => {
+            const isItemSelected = selectedItems.filter((i) => i.id === item.id).length;
+            return `${item.col1} is ${isItemSelected ? '' : 'not '}selected`;
+          },
+        }}
+        variant="full-page"
+        stickyHeader
+      />
+    </SpaceBetween>
+  );
+}

--- a/src/pages/administrative-dashboard/components/content.tsx
+++ b/src/pages/administrative-dashboard/components/content.tsx
@@ -259,12 +259,22 @@ export function DashboardContent() {
             countText={`${filteredItemsCount} ${filteredItemsCount === 1 ? 'match' : 'matches'}`}
           />
         }
-        pagination={<Pagination {...paginationProps} ariaLabels={{ nextPageLabel: 'Next page', previousPageLabel: 'Previous page', pageLabel: (pageNumber) => `Page ${pageNumber}` }} />}
+        pagination={
+          <Pagination
+            {...paginationProps}
+            ariaLabels={{
+              nextPageLabel: 'Next page',
+              previousPageLabel: 'Previous page',
+              pageLabel: pageNumber => `Page ${pageNumber}`,
+            }}
+          />
+        }
         ariaLabels={{
           selectionGroupLabel: 'Items selection',
-          allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+          allItemsSelectionLabel: ({ selectedItems }) =>
+            `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
           itemSelectionLabel: ({ selectedItems }, item) => {
-            const isItemSelected = selectedItems.filter((i) => i.id === item.id).length;
+            const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
             return `${item.col1} is ${isItemSelected ? '' : 'not '}selected`;
           },
         }}

--- a/src/pages/administrative-dashboard/index.tsx
+++ b/src/pages/administrative-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function AdministrativeDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,12 @@ import Link from '@cloudscape-design/components/link';
 
 // Demo definitions with category information
 const demos = [
+  {
+    route: '/administrative-dashboard',
+    title: 'Administrative Dashboard',
+    description: 'Dashboard with charts, tables, and data visualization.',
+    category: 'Dashboards',
+  },
   { route: '/cards', title: 'Card View', description: 'Demo of Cloudscape Cards component.', category: 'Components' },
   { route: '/chat', title: 'Chat', description: 'Chat UI demo.', category: 'Applications' },
   {


### PR DESCRIPTION
## Summary
This PR implements a new Administrative Dashboard page featuring data visualization charts and a comprehensive data table, built using Cloudscape Design components.

## Problem
The project required a fully responsive dashboard implementation based on design specifications, ensuring it works seamlessly across desktop and mobile views while displaying complex data.

## Solution
I utilized the Cloudscape Design system to construct a responsive layout. `AppLayout` handles the overall structure, while `AreaChart`, `BarChart`, and `Table` components are used to visualize the data, ensuring accessibility and responsiveness out of the box.

## Key Changes
- Added a new administrative dashboard route and page.
- Implemented a responsive `AppLayout` with `TopNavigation`.
- Created a content section containing an Area Chart and a Bar Chart.
- Added a feature-rich table with pagination, filtering, and multi-selection.
- Integrated mock data for visualization and tabular display.

## Files Changed
- **src/pages/administrative-dashboard/app.tsx**: Set up the main application shell with navigation and layout.
- **src/pages/administrative-dashboard/components/content.tsx**: Implemented the dashboard widgets, including charts and the main data table.
- **src/pages/administrative-dashboard/index.tsx**: Created the entry point for the new dashboard page.
- **src/pages/index.tsx**: Registered the new "Administrative Dashboard" route in the main demo list.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/flare-field)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-flare-field.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>flare-field</branchName>-->