### PR TITLE
Add Administration Dashboard page with charts and table

### DIFF
--- a/src/pages/admin-dashboard/index.tsx
+++ b/src/pages/admin-dashboard/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT-0
 import React, { useState } from 'react';
 import AppLayout from '@cloudscape-design/components/app-layout';
-import TopNavigation from '@cloudscape-design/components/top-navigation';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
 import Header from '@cloudscape-design/components/header';
 import Button from '@cloudscape-design/components/button';
@@ -87,7 +86,7 @@ const generateTableData = () => {
 export default function AdminDashboard() {
   const [filterText, setFilterText] = useState('');
   const [currentPageIndex, setCurrentPageIndex] = useState(1);
-  const [selectedItems, setSelectedItems] = useState([]);
+  const [selectedItems, setSelectedItems] = useState<any[]>([]);
 
   const tableData = generateTableData();
 
@@ -95,281 +94,207 @@ export default function AdminDashboard() {
     {
       id: 'column1',
       header: 'Column header',
-      cell: item => item.column1,
+      cell: (item: any) => item.column1,
       sortingField: 'column1',
     },
     {
       id: 'column2',
       header: 'Column header',
-      cell: item => item.column2,
+      cell: (item: any) => item.column2,
       sortingField: 'column2',
     },
     {
       id: 'column3',
       header: 'Column header',
-      cell: item => item.column3,
+      cell: (item: any) => item.column3,
       sortingField: 'column3',
     },
     {
       id: 'column4',
       header: 'Column header',
-      cell: item => item.column4,
+      cell: (item: any) => item.column4,
       sortingField: 'column4',
     },
     {
       id: 'column5',
       header: 'Column header',
-      cell: item => item.column5,
+      cell: (item: any) => item.column5,
       sortingField: 'column5',
     },
     {
       id: 'column6',
       header: 'Column header',
-      cell: item => item.column6,
+      cell: (item: any) => item.column6,
       sortingField: 'column6',
     },
     {
       id: 'column7',
       header: 'Column header',
-      cell: item => item.column7,
+      cell: (item: any) => item.column7,
       sortingField: 'column7',
     },
   ];
 
   return (
-    <>
-      <TopNavigation
-        identity={{
-          href: '#',
-          title: 'Service name',
-          logo: {
-            src: '',
-            alt: 'Service name logo',
-          },
-        }}
-        utilities={[
-          {
-            type: 'button',
-            text: 'Link',
-            href: 'https://example.com/',
-            external: true,
-            externalIconAriaLabel: ' (opens in a new tab)',
-          },
-          {
-            type: 'button',
-            iconName: 'notification',
-            title: 'Notifications',
-            ariaLabel: 'Notifications (unread)',
-            badge: true,
-            disableUtilityCollapse: false,
-          },
-          {
-            type: 'button',
-            iconName: 'settings',
-            title: 'Settings',
-            ariaLabel: 'Settings',
-          },
-          {
-            type: 'menu-dropdown',
-            iconName: 'user-profile',
-            text: 'Customer name',
-            items: [
-              { id: 'profile', text: 'Profile' },
-              { id: 'preferences', text: 'Preferences' },
-              { id: 'security', text: 'Security' },
-              {
-                id: 'support-group',
-                text: 'Support',
-                items: [
-                  {
-                    id: 'documentation',
-                    text: 'Documentation',
-                    href: '#',
-                    external: true,
-                    externalIconAriaLabel: ' (opens in new tab)',
-                  },
-                  { id: 'feedback', text: 'Feedback', href: '#', external: true },
-                  { id: 'support', text: 'Customer support' },
-                ],
-              },
-              { id: 'signout', text: 'Sign out' },
-            ],
-          },
-        ]}
-        i18nStrings={{
-          searchIconAriaLabel: 'Search',
-          searchDismissIconAriaLabel: 'Close search',
-          overflowMenuTriggerText: 'More',
-          overflowMenuTitleText: 'All',
-          overflowMenuBackIconAriaLabel: 'Back',
-          overflowMenuDismissIconAriaLabel: 'Close menu',
-        }}
-      />
-      <AppLayout
-        breadcrumbs={
-          <BreadcrumbGroup
-            items={[
-              { text: 'Service', href: '#' },
-              { text: 'Administrative Dashboard', href: '#' },
+    <AppLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '#' },
+            { text: 'Administrative Dashboard', href: '#' },
+          ]}
+          ariaLabel="Breadcrumbs"
+        />
+      }
+      navigationHide
+      toolsHide
+      content={
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            description="Collection description"
+            actions={
+              <Button variant="primary" iconName="external" iconAlign="right">
+                Refresh Data
+              </Button>
+            }
+          >
+            Administration Dashboard
+          </Header>
+
+          <Grid
+            gridDefinition={[
+              { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+              { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
             ]}
-            ariaLabel="Breadcrumbs"
+          >
+            <Container>
+              <AreaChart
+                series={areaChartData}
+                xDomain={[new Date('2024-01-01'), new Date('2024-12-01')]}
+                yDomain={[0, 6]}
+                i18nStrings={{
+                  filterLabel: 'Filter displayed data',
+                  filterPlaceholder: 'Filter data',
+                  filterSelectedAriaLabel: 'selected',
+                  legendAriaLabel: 'Legend',
+                  chartAriaRoleDescription: 'area chart',
+                  xAxisAriaRoleDescription: 'x axis',
+                  yAxisAriaRoleDescription: 'y axis',
+                }}
+                ariaLabel="Area chart example"
+                height={300}
+                xScaleType="time"
+                xTitle="X-axis label"
+                yTitle="y-axis label"
+                empty={
+                  <Box textAlign="center" color="inherit">
+                    <b>No data available</b>
+                    <Box variant="p" color="inherit">
+                      There is no data available
+                    </Box>
+                  </Box>
+                }
+                noMatch={
+                  <Box textAlign="center" color="inherit">
+                    <b>No matching data</b>
+                    <Box variant="p" color="inherit">
+                      There is no matching data to display
+                    </Box>
+                  </Box>
+                }
+              />
+            </Container>
+
+            <Container>
+              <BarChart
+                series={[
+                  {
+                    title: 'Site 1',
+                    type: 'bar',
+                    data: barChartData,
+                  },
+                ]}
+                xDomain={barChartData.map(d => d.x)}
+                yDomain={[0, 300]}
+                i18nStrings={{
+                  filterLabel: 'Filter displayed data',
+                  filterPlaceholder: 'Filter data',
+                  filterSelectedAriaLabel: 'selected',
+                  legendAriaLabel: 'Legend',
+                  chartAriaRoleDescription: 'bar chart',
+                  xAxisAriaRoleDescription: 'x axis',
+                  yAxisAriaRoleDescription: 'y axis',
+                }}
+                ariaLabel="Bar chart example"
+                height={300}
+                xScaleType="categorical"
+                xTitle="X-axis label"
+                yTitle="y-axis label"
+                empty={
+                  <Box textAlign="center" color="inherit">
+                    <b>No data available</b>
+                    <Box variant="p" color="inherit">
+                      There is no data available
+                    </Box>
+                  </Box>
+                }
+                noMatch={
+                  <Box textAlign="center" color="inherit">
+                    <b>No matching data</b>
+                    <Box variant="p" color="inherit">
+                      There is no matching data to display
+                    </Box>
+                  </Box>
+                }
+              />
+            </Container>
+          </Grid>
+
+          <Table
+            columnDefinitions={columnDefinitions}
+            items={tableData}
+            selectionType="multi"
+            selectedItems={selectedItems}
+            onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+            ariaLabels={{
+              selectionGroupLabel: 'Items selection',
+              allItemsSelectionLabel: () => 'select all',
+              itemSelectionLabel: ({ selectedItems }, item) => {
+                const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
+                return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
+              },
+            }}
+            header={
+              <Header
+                actions={
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <TextFilter
+                      filteringText={filterText}
+                      filteringPlaceholder="Placeholder"
+                      filteringAriaLabel="Filter table items"
+                      onChange={({ detail }) => setFilterText(detail.filteringText)}
+                    />
+                  </SpaceBetween>
+                }
+              />
+            }
+            pagination={
+              <Pagination
+                currentPageIndex={currentPageIndex}
+                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                pagesCount={5}
+                ariaLabels={{
+                  nextPageLabel: 'Next page',
+                  previousPageLabel: 'Previous page',
+                  pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+                }}
+              />
+            }
+            preferences={<Button iconName="settings" variant="icon" ariaLabel="Preferences" />}
           />
-        }
-        navigationHide
-        toolsHide
-        content={
-          <SpaceBetween size="l">
-            <Header
-              variant="h1"
-              description="Collection description"
-              actions={
-                <Button variant="primary" iconName="external" iconAlign="right">
-                  Refresh Data
-                </Button>
-              }
-            >
-              Administration Dashboard
-            </Header>
-
-            <Grid
-              gridDefinition={[
-                { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
-                { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
-              ]}
-            >
-              <Container>
-                <AreaChart
-                  series={areaChartData}
-                  xDomain={[
-                    new Date('2024-01-01'),
-                    new Date('2024-12-01'),
-                  ]}
-                  yDomain={[0, 6]}
-                  i18nStrings={{
-                    filterLabel: 'Filter displayed data',
-                    filterPlaceholder: 'Filter data',
-                    filterSelectedAriaLabel: 'selected',
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'area chart',
-                    xAxisAriaRoleDescription: 'x axis',
-                    yAxisAriaRoleDescription: 'y axis',
-                  }}
-                  ariaLabel="Area chart example"
-                  height={300}
-                  xScaleType="time"
-                  xTitle="X-axis label"
-                  yTitle="y-axis label"
-                  empty={
-                    <Box textAlign="center" color="inherit">
-                      <b>No data available</b>
-                      <Box variant="p" color="inherit">
-                        There is no data available
-                      </Box>
-                    </Box>
-                  }
-                  noMatch={
-                    <Box textAlign="center" color="inherit">
-                      <b>No matching data</b>
-                      <Box variant="p" color="inherit">
-                        There is no matching data to display
-                      </Box>
-                    </Box>
-                  }
-                />
-              </Container>
-
-              <Container>
-                <BarChart
-                  series={[
-                    {
-                      title: 'Site 1',
-                      type: 'bar',
-                      data: barChartData,
-                    },
-                  ]}
-                  xDomain={barChartData.map(d => d.x)}
-                  yDomain={[0, 300]}
-                  i18nStrings={{
-                    filterLabel: 'Filter displayed data',
-                    filterPlaceholder: 'Filter data',
-                    filterSelectedAriaLabel: 'selected',
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'bar chart',
-                    xAxisAriaRoleDescription: 'x axis',
-                    yAxisAriaRoleDescription: 'y axis',
-                  }}
-                  ariaLabel="Bar chart example"
-                  height={300}
-                  xScaleType="categorical"
-                  xTitle="X-axis label"
-                  yTitle="y-axis label"
-                  empty={
-                    <Box textAlign="center" color="inherit">
-                      <b>No data available</b>
-                      <Box variant="p" color="inherit">
-                        There is no data available
-                      </Box>
-                    </Box>
-                  }
-                  noMatch={
-                    <Box textAlign="center" color="inherit">
-                      <b>No matching data</b>
-                      <Box variant="p" color="inherit">
-                        There is no matching data to display
-                      </Box>
-                    </Box>
-                  }
-                />
-              </Container>
-            </Grid>
-
-            <Table
-              columnDefinitions={columnDefinitions}
-              items={tableData}
-              selectionType="multi"
-              selectedItems={selectedItems}
-              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
-              ariaLabels={{
-                selectionGroupLabel: 'Items selection',
-                allItemsSelectionLabel: () => 'select all',
-                itemSelectionLabel: ({ selectedItems }, item) => {
-                  const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
-                  return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
-                },
-              }}
-              header={
-                <Header
-                  actions={
-                    <SpaceBetween direction="horizontal" size="xs">
-                      <TextFilter
-                        filteringText={filterText}
-                        filteringPlaceholder="Placeholder"
-                        filteringAriaLabel="Filter table items"
-                        onChange={({ detail }) => setFilterText(detail.filteringText)}
-                      />
-                    </SpaceBetween>
-                  }
-                />
-              }
-              pagination={
-                <Pagination
-                  currentPageIndex={currentPageIndex}
-                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
-                  pagesCount={5}
-                  ariaLabels={{
-                    nextPageLabel: 'Next page',
-                    previousPageLabel: 'Previous page',
-                    pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
-                  }}
-                />
-              }
-              preferences={
-                <Button iconName="settings" variant="icon" ariaLabel="Preferences" />
-              }
-            />
-          </SpaceBetween>
-        }
-      />
-    </>
+        </SpaceBetween>
+      }
+    />
   );
 }

--- a/src/pages/admin-dashboard/index.tsx
+++ b/src/pages/admin-dashboard/index.tsx
@@ -17,67 +17,95 @@ import BarChart from '@cloudscape-design/components/bar-chart';
 
 import '../../styles/base.scss';
 
-// Sample data for the charts
+// Sample data for the charts - simulating realistic metrics over time
 const areaChartData = [
   {
-    title: 'Site 1',
+    title: 'North America Traffic',
     type: 'area',
     data: [
-      { x: new Date('2024-01-01'), y: 2 },
-      { x: new Date('2024-02-01'), y: 3 },
-      { x: new Date('2024-03-01'), y: 3.5 },
-      { x: new Date('2024-04-01'), y: 4 },
-      { x: new Date('2024-05-01'), y: 4.5 },
-      { x: new Date('2024-06-01'), y: 5 },
-      { x: new Date('2024-07-01'), y: 5 },
-      { x: new Date('2024-08-01'), y: 4.8 },
-      { x: new Date('2024-09-01'), y: 5.2 },
-      { x: new Date('2024-10-01'), y: 5.5 },
-      { x: new Date('2024-11-01'), y: 5.3 },
-      { x: new Date('2024-12-01'), y: 5.5 },
+      { x: new Date('2024-01-01'), y: 12500 },
+      { x: new Date('2024-02-01'), y: 14200 },
+      { x: new Date('2024-03-01'), y: 15800 },
+      { x: new Date('2024-04-01'), y: 18300 },
+      { x: new Date('2024-05-01'), y: 21500 },
+      { x: new Date('2024-06-01'), y: 24100 },
+      { x: new Date('2024-07-01'), y: 26700 },
+      { x: new Date('2024-08-01'), y: 25300 },
+      { x: new Date('2024-09-01'), y: 28900 },
+      { x: new Date('2024-10-01'), y: 31200 },
+      { x: new Date('2024-11-01'), y: 29800 },
+      { x: new Date('2024-12-01'), y: 33500 },
     ],
   },
   {
-    title: 'Site 2',
+    title: 'Europe Traffic',
     type: 'area',
     data: [
-      { x: new Date('2024-01-01'), y: 2.5 },
-      { x: new Date('2024-02-01'), y: 3.2 },
-      { x: new Date('2024-03-01'), y: 3 },
-      { x: new Date('2024-04-01'), y: 3.8 },
-      { x: new Date('2024-05-01'), y: 4.2 },
-      { x: new Date('2024-06-01'), y: 4.5 },
-      { x: new Date('2024-07-01'), y: 4.3 },
-      { x: new Date('2024-08-01'), y: 4.7 },
-      { x: new Date('2024-09-01'), y: 4.9 },
-      { x: new Date('2024-10-01'), y: 5.1 },
-      { x: new Date('2024-11-01'), y: 5.3 },
-      { x: new Date('2024-12-01'), y: 5.2 },
+      { x: new Date('2024-01-01'), y: 8900 },
+      { x: new Date('2024-02-01'), y: 10200 },
+      { x: new Date('2024-03-01'), y: 9500 },
+      { x: new Date('2024-04-01'), y: 11800 },
+      { x: new Date('2024-05-01'), y: 14200 },
+      { x: new Date('2024-06-01'), y: 16500 },
+      { x: new Date('2024-07-01'), y: 15900 },
+      { x: new Date('2024-08-01'), y: 17400 },
+      { x: new Date('2024-09-01'), y: 19200 },
+      { x: new Date('2024-10-01'), y: 20800 },
+      { x: new Date('2024-11-01'), y: 22100 },
+      { x: new Date('2024-12-01'), y: 21500 },
+    ],
+  },
+  {
+    title: 'Asia Pacific Traffic',
+    type: 'area',
+    data: [
+      { x: new Date('2024-01-01'), y: 6200 },
+      { x: new Date('2024-02-01'), y: 7800 },
+      { x: new Date('2024-03-01'), y: 8900 },
+      { x: new Date('2024-04-01'), y: 10500 },
+      { x: new Date('2024-05-01'), y: 12800 },
+      { x: new Date('2024-06-01'), y: 14200 },
+      { x: new Date('2024-07-01'), y: 16900 },
+      { x: new Date('2024-08-01'), y: 18500 },
+      { x: new Date('2024-09-01'), y: 20100 },
+      { x: new Date('2024-10-01'), y: 22700 },
+      { x: new Date('2024-11-01'), y: 24300 },
+      { x: new Date('2024-12-01'), y: 26800 },
     ],
   },
 ];
 
 const barChartData = [
-  { x: 'x1', y: 183 },
-  { x: 'x2', y: 257 },
-  { x: 'x3', y: 213 },
-  { x: 'x4', y: 122 },
-  { x: 'x5', y: 210 },
+  { x: 'Q1 2024', y: 18300 },
+  { x: 'Q2 2024', y: 25700 },
+  { x: 'Q3 2024', y: 21300 },
+  { x: 'Q4 2024', y: 29400 },
+  { x: 'Q1 2025', y: 32100 },
+  { x: 'Q2 2025 (Projected)', y: 35800 },
 ];
 
-// Sample table data
+// Sample table data - simulating resource metrics
 const generateTableData = () => {
+  const regions = ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-northeast-1'];
+  const statuses = ['Active', 'Idle', 'Maintenance', 'Active', 'Active', 'Idle'];
+  const instanceTypes = ['t3.large', 't3.xlarge', 'm5.large', 'm5.xlarge', 'c5.large', 'c5.xlarge'];
+
   const data = [];
-  for (let i = 1; i <= 12; i++) {
+  for (let i = 0; i < 12; i++) {
+    const region = regions[i % regions.length];
+    const cpuUsage = Math.floor(Math.random() * 60) + 20;
+    const memoryUsage = Math.floor(Math.random() * 70) + 15;
+    const networkIO = (Math.random() * 500 + 100).toFixed(2);
+
     data.push({
-      id: `item-${i}`,
-      column1: 'Cell Value',
-      column2: 'Cell Value',
-      column3: 'Cell Value',
-      column4: 'Cell Value',
-      column5: 'Cell Value',
-      column6: 'Cell Value',
-      column7: 'Cell Value',
+      id: `resource-${i + 1}`,
+      column1: `srv-${region}-${String(i + 1).padStart(3, '0')}`,
+      column2: region,
+      column3: instanceTypes[i % instanceTypes.length],
+      column4: statuses[i % statuses.length],
+      column5: `${cpuUsage}%`,
+      column6: `${memoryUsage}%`,
+      column7: `${networkIO} Mbps`,
     });
   }
   return data;
@@ -93,45 +121,52 @@ export default function AdminDashboard() {
   const columnDefinitions = [
     {
       id: 'column1',
-      header: 'Column header',
+      header: 'Resource ID',
       cell: (item: any) => item.column1,
       sortingField: 'column1',
+      width: 180,
     },
     {
       id: 'column2',
-      header: 'Column header',
+      header: 'Region',
       cell: (item: any) => item.column2,
       sortingField: 'column2',
+      width: 140,
     },
     {
       id: 'column3',
-      header: 'Column header',
+      header: 'Instance Type',
       cell: (item: any) => item.column3,
       sortingField: 'column3',
+      width: 130,
     },
     {
       id: 'column4',
-      header: 'Column header',
+      header: 'Status',
       cell: (item: any) => item.column4,
       sortingField: 'column4',
+      width: 110,
     },
     {
       id: 'column5',
-      header: 'Column header',
+      header: 'CPU Usage',
       cell: (item: any) => item.column5,
       sortingField: 'column5',
+      width: 110,
     },
     {
       id: 'column6',
-      header: 'Column header',
+      header: 'Memory Usage',
       cell: (item: any) => item.column6,
       sortingField: 'column6',
+      width: 130,
     },
     {
       id: 'column7',
-      header: 'Column header',
+      header: 'Network I/O',
       cell: (item: any) => item.column7,
       sortingField: 'column7',
+      width: 120,
     },
   ];
 
@@ -172,7 +207,7 @@ export default function AdminDashboard() {
               <AreaChart
                 series={areaChartData}
                 xDomain={[new Date('2024-01-01'), new Date('2024-12-01')]}
-                yDomain={[0, 6]}
+                yDomain={[0, 35000]}
                 i18nStrings={{
                   filterLabel: 'Filter displayed data',
                   filterPlaceholder: 'Filter data',
@@ -216,7 +251,7 @@ export default function AdminDashboard() {
                   },
                 ]}
                 xDomain={barChartData.map(d => d.x)}
-                yDomain={[0, 300]}
+                yDomain={[0, 40000]}
                 i18nStrings={{
                   filterLabel: 'Filter displayed data',
                   filterPlaceholder: 'Filter data',

--- a/src/pages/admin-dashboard/index.tsx
+++ b/src/pages/admin-dashboard/index.tsx
@@ -1,0 +1,375 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Grid from '@cloudscape-design/components/grid';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+
+import '../../styles/base.scss';
+
+// Sample data for the charts
+const areaChartData = [
+  {
+    title: 'Site 1',
+    type: 'area',
+    data: [
+      { x: new Date('2024-01-01'), y: 2 },
+      { x: new Date('2024-02-01'), y: 3 },
+      { x: new Date('2024-03-01'), y: 3.5 },
+      { x: new Date('2024-04-01'), y: 4 },
+      { x: new Date('2024-05-01'), y: 4.5 },
+      { x: new Date('2024-06-01'), y: 5 },
+      { x: new Date('2024-07-01'), y: 5 },
+      { x: new Date('2024-08-01'), y: 4.8 },
+      { x: new Date('2024-09-01'), y: 5.2 },
+      { x: new Date('2024-10-01'), y: 5.5 },
+      { x: new Date('2024-11-01'), y: 5.3 },
+      { x: new Date('2024-12-01'), y: 5.5 },
+    ],
+  },
+  {
+    title: 'Site 2',
+    type: 'area',
+    data: [
+      { x: new Date('2024-01-01'), y: 2.5 },
+      { x: new Date('2024-02-01'), y: 3.2 },
+      { x: new Date('2024-03-01'), y: 3 },
+      { x: new Date('2024-04-01'), y: 3.8 },
+      { x: new Date('2024-05-01'), y: 4.2 },
+      { x: new Date('2024-06-01'), y: 4.5 },
+      { x: new Date('2024-07-01'), y: 4.3 },
+      { x: new Date('2024-08-01'), y: 4.7 },
+      { x: new Date('2024-09-01'), y: 4.9 },
+      { x: new Date('2024-10-01'), y: 5.1 },
+      { x: new Date('2024-11-01'), y: 5.3 },
+      { x: new Date('2024-12-01'), y: 5.2 },
+    ],
+  },
+];
+
+const barChartData = [
+  { x: 'x1', y: 183 },
+  { x: 'x2', y: 257 },
+  { x: 'x3', y: 213 },
+  { x: 'x4', y: 122 },
+  { x: 'x5', y: 210 },
+];
+
+// Sample table data
+const generateTableData = () => {
+  const data = [];
+  for (let i = 1; i <= 12; i++) {
+    data.push({
+      id: `item-${i}`,
+      column1: 'Cell Value',
+      column2: 'Cell Value',
+      column3: 'Cell Value',
+      column4: 'Cell Value',
+      column5: 'Cell Value',
+      column6: 'Cell Value',
+      column7: 'Cell Value',
+    });
+  }
+  return data;
+};
+
+export default function AdminDashboard() {
+  const [filterText, setFilterText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  const tableData = generateTableData();
+
+  const columnDefinitions = [
+    {
+      id: 'column1',
+      header: 'Column header',
+      cell: item => item.column1,
+      sortingField: 'column1',
+    },
+    {
+      id: 'column2',
+      header: 'Column header',
+      cell: item => item.column2,
+      sortingField: 'column2',
+    },
+    {
+      id: 'column3',
+      header: 'Column header',
+      cell: item => item.column3,
+      sortingField: 'column3',
+    },
+    {
+      id: 'column4',
+      header: 'Column header',
+      cell: item => item.column4,
+      sortingField: 'column4',
+    },
+    {
+      id: 'column5',
+      header: 'Column header',
+      cell: item => item.column5,
+      sortingField: 'column5',
+    },
+    {
+      id: 'column6',
+      header: 'Column header',
+      cell: item => item.column6,
+      sortingField: 'column6',
+    },
+    {
+      id: 'column7',
+      header: 'Column header',
+      cell: item => item.column7,
+      sortingField: 'column7',
+    },
+  ];
+
+  return (
+    <>
+      <TopNavigation
+        identity={{
+          href: '#',
+          title: 'Service name',
+          logo: {
+            src: '',
+            alt: 'Service name logo',
+          },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            text: 'Link',
+            href: 'https://example.com/',
+            external: true,
+            externalIconAriaLabel: ' (opens in a new tab)',
+          },
+          {
+            type: 'button',
+            iconName: 'notification',
+            title: 'Notifications',
+            ariaLabel: 'Notifications (unread)',
+            badge: true,
+            disableUtilityCollapse: false,
+          },
+          {
+            type: 'button',
+            iconName: 'settings',
+            title: 'Settings',
+            ariaLabel: 'Settings',
+          },
+          {
+            type: 'menu-dropdown',
+            iconName: 'user-profile',
+            text: 'Customer name',
+            items: [
+              { id: 'profile', text: 'Profile' },
+              { id: 'preferences', text: 'Preferences' },
+              { id: 'security', text: 'Security' },
+              {
+                id: 'support-group',
+                text: 'Support',
+                items: [
+                  {
+                    id: 'documentation',
+                    text: 'Documentation',
+                    href: '#',
+                    external: true,
+                    externalIconAriaLabel: ' (opens in new tab)',
+                  },
+                  { id: 'feedback', text: 'Feedback', href: '#', external: true },
+                  { id: 'support', text: 'Customer support' },
+                ],
+              },
+              { id: 'signout', text: 'Sign out' },
+            ],
+          },
+        ]}
+        i18nStrings={{
+          searchIconAriaLabel: 'Search',
+          searchDismissIconAriaLabel: 'Close search',
+          overflowMenuTriggerText: 'More',
+          overflowMenuTitleText: 'All',
+          overflowMenuBackIconAriaLabel: 'Back',
+          overflowMenuDismissIconAriaLabel: 'Close menu',
+        }}
+      />
+      <AppLayout
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#' },
+              { text: 'Administrative Dashboard', href: '#' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+        }
+        navigationHide
+        toolsHide
+        content={
+          <SpaceBetween size="l">
+            <Header
+              variant="h1"
+              description="Collection description"
+              actions={
+                <Button variant="primary" iconName="external" iconAlign="right">
+                  Refresh Data
+                </Button>
+              }
+            >
+              Administration Dashboard
+            </Header>
+
+            <Grid
+              gridDefinition={[
+                { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+                { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+              ]}
+            >
+              <Container>
+                <AreaChart
+                  series={areaChartData}
+                  xDomain={[
+                    new Date('2024-01-01'),
+                    new Date('2024-12-01'),
+                  ]}
+                  yDomain={[0, 6]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xAxisAriaRoleDescription: 'x axis',
+                    yAxisAriaRoleDescription: 'y axis',
+                  }}
+                  ariaLabel="Area chart example"
+                  height={300}
+                  xScaleType="time"
+                  xTitle="X-axis label"
+                  yTitle="y-axis label"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+
+              <Container>
+                <BarChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'bar',
+                      data: barChartData,
+                    },
+                  ]}
+                  xDomain={barChartData.map(d => d.x)}
+                  yDomain={[0, 300]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    xAxisAriaRoleDescription: 'x axis',
+                    yAxisAriaRoleDescription: 'y axis',
+                  }}
+                  ariaLabel="Bar chart example"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="X-axis label"
+                  yTitle="y-axis label"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+            </Grid>
+
+            <Table
+              columnDefinitions={columnDefinitions}
+              items={tableData}
+              selectionType="multi"
+              selectedItems={selectedItems}
+              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+              ariaLabels={{
+                selectionGroupLabel: 'Items selection',
+                allItemsSelectionLabel: () => 'select all',
+                itemSelectionLabel: ({ selectedItems }, item) => {
+                  const isItemSelected = selectedItems.filter(i => i.id === item.id).length;
+                  return `${item.id} is ${isItemSelected ? '' : 'not'} selected`;
+                },
+              }}
+              header={
+                <Header
+                  actions={
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <TextFilter
+                        filteringText={filterText}
+                        filteringPlaceholder="Placeholder"
+                        filteringAriaLabel="Filter table items"
+                        onChange={({ detail }) => setFilterText(detail.filteringText)}
+                      />
+                    </SpaceBetween>
+                  }
+                />
+              }
+              pagination={
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                  pagesCount={5}
+                  ariaLabels={{
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+                  }}
+                />
+              }
+              preferences={
+                <Button iconName="settings" variant="icon" ariaLabel="Preferences" />
+              }
+            />
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,12 @@ import Link from '@cloudscape-design/components/link';
 
 // Demo definitions with category information
 const demos = [
+  {
+    route: '/admin-dashboard',
+    title: 'Administration Dashboard',
+    description: 'Admin dashboard with charts and data tables.',
+    category: 'Dashboards',
+  },
   { route: '/cards', title: 'Card View', description: 'Demo of Cloudscape Cards component.', category: 'Components' },
   { route: '/chat', title: 'Chat', description: 'Chat UI demo.', category: 'Applications' },
   {


### PR DESCRIPTION
## Summary
This PR adds a new "Administration Dashboard" page featuring responsive data visualization charts and a data table using Cloudscape components.

## Problem
The project required a responsive administration dashboard implementation to visualize site data and manage records, based on design specifications.

## Solution
Created a new page utilizing Cloudscape's `AppLayout`, `Grid`, `AreaChart`, `BarChart`, and `Table` components. The layout is designed to be fully responsive, stacking elements on smaller screens and arranging them side-by-side on larger ones.

## Key Changes
*   **New Page**: Added `src/pages/admin-dashboard/index.tsx` implementing the dashboard view.
*   **Charts**: Added Area and Bar charts with sample datasets to visualize site performance.
*   **Table Interface**: Added a data table with text filter placeholder, pagination, and multi-select capabilities.
*   **Routing**: Registered the new page in the demo directory in `src/pages/index.tsx`.

## Files Changed
*   `src/pages/admin-dashboard/index.tsx`: Implemented the dashboard logic and UI.
*   `src/pages/index.tsx`: Added the dashboard to the list of available demos.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b17ad953df714022aa95eec3ca45390c/aura-nest)

👀 [Preview Link](https://b17ad953df714022aa95eec3ca45390c-aura-nest.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b17ad953df714022aa95eec3ca45390c</projectId>-->
<!--<branchName>aura-nest</branchName>-->